### PR TITLE
Add mkdir for GEOSERVER_DATA_DIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get -y update
 ENV GS_VERSION 2.8.2
 ENV GEOSERVER_DATA_DIR /opt/geoserver/data_dir
 
+RUN mkdir -p $GEOSERVER_DATA_DIR
+
 # Unset Java related ENVs since they may change with Oracle JDK
 ENV JAVA_VERSION=
 ENV JAVA_DEBIAN_VERSION=


### PR DESCRIPTION
This Dockerfile sets the ENV but doesn't create the directory, leading to geoserver outputting things like these in the logs:

```
ERROR [storage.DefaultStorageFinder] - Found System environment variable GEOSERVER_DATA_DIR set to /opt/geoserver/data_dir , but this path does not exist
...
WARN [geoserver.global] - Found System environment variable GEOSERVER_DATA_DIR set to /opt/geoserver/data_dir , but this path does not exist
...
INFO [geoserver.global] - Falling back to embedded data directory: /usr/local/tomcat/webapps/geoserver/data
```