### PR TITLE
Added extra options for geoserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV GEOSERVER_OPTS "-Djava.awt.headless=true -server -Xms2G -Xmx4G -Xrs -XX:Perf
 #-XX:+UseConcMarkSweepGC use this rather than parallel GC?  
 ENV JAVA_OPTS "$JAVA_OPTS $GEOSERVER_OPTS"
 ENV GDAL_DATA /usr/local/gdal_data
-ENV LD_LIBRARY_PATH /usr/local/gdal_native_libs:/usr/local/apr/lib
+ENV LD_LIBRARY_PATH /usr/local/gdal_native_libs:/usr/local/apr/lib:/opt/libjpeg-turbo/lib64
 ENV GEOSERVER_LOG_LOCATION /opt/geoserver/data_dir/logs/geoserver.log
 
 RUN mkdir -p $GEOSERVER_DATA_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update
 
 #-------------Application Specific Stuff ----------------------------------------------------
 
-ENV GS_VERSION 2.12.2
+ENV GS_VERSION 2.12.1
 ENV GEOSERVER_DATA_DIR /opt/geoserver/data_dir
 
 ENV GEOSERVER_OPTS "-Djava.awt.headless=true -server -Xms2G -Xmx4G -Xrs -XX:PerfDataSamplingInterval=500 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,9 +142,6 @@ RUN if ls /tmp/resources/plugins/*.zip > /dev/null 2>&1; then \
     unzip /tmp/resources/plugins/gdal/gdal-data.zip -d /usr/local/gdal_data && \
     tar xzf /tmp/resources/plugins/gdal192-Ubuntu12-gcc4.6.3-x86_64.tar.gz -C /usr/local/gdal_native_libs; \
     fi;
-#TODO
-#install http://docs.geoserver.org/2.9.2/user/extensions/libjpeg-turbo/index.html#community-libjpeg-turbo
-#install Apache Tomcat Native library
 
 # Overlay files and directories in resources/overlays if they exist
 RUN rm -f /tmp/resources/overlays/README.txt && \
@@ -153,7 +150,7 @@ RUN rm -f /tmp/resources/overlays/README.txt && \
     fi;
 
 # Optionally remove Tomcat manager, docs, and examples
-#ARG TOMCAT_EXTRAS=true #moved to docker-compose.yml
+ARG TOMCAT_EXTRAS=true
 RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
     rm -rf $CATALINA_HOME/webapps/ROOT && \
     rm -rf $CATALINA_HOME/webapps/docs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,11 @@ ENV JAVA_HOME /usr/lib/jvm/default-java
 ADD resources /tmp/resources
 
 # Install libjpeg-turbo for that specific geoserver version
-RUN if ls /tmp/resource/libjpeg-turbo-official_1.5.3_amd64.deb; then \
-    dpkg -i /tmp/resource/libjpeg-turbo-official_1.5.3_amd64.deb
+RUN if [ ! -f /tmp/resources/libjpeg-turbo-official_1.5.3_amd64.deb ]; then \
+    wget https://tenet.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-official_1.5.3_amd64.deb -P ./resources;\
     fi;
 
-
+RUN dpkg -i libjpeg-turbo-official_1.5.3_amd64.deb
 # If a matching Oracle JDK tar.gz exists in /tmp/resources, move it to /var/cache/oracle-jdk8-installer
 # where oracle-java8-installer will detect it
 RUN if ls /tmp/resources/*jdk-*-linux-x64.tar.gz > /dev/null 2>&1; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV GEOSERVER_OPTS "-Djava.awt.headless=true -server -Xms2G -Xmx4G -Xrs -XX:Perf
 #-XX:+UseConcMarkSweepGC use this rather than parallel GC?  
 ENV JAVA_OPTS "$JAVA_OPTS $GEOSERVER_OPTS"
 ENV GDAL_DATA /usr/local/gdal_data
-ENV LD_LIBRARY_PATH /usr/local/gdal_native_libs
+ENV LD_LIBRARY_PATH /usr/local/gdal_native_libs:/usr/local/apr/lib
 ENV GEOSERVER_LOG_LOCATION /opt/geoserver/data_dir/logs/geoserver.log
 
 RUN mkdir -p $GEOSERVER_DATA_DIR
@@ -65,7 +65,6 @@ RUN if [ ! -f /tmp/resources/tomcat-native-1.2.16-src.tar.gz ]; then \
     ./configure --with-java-home=${JAVA_HOME} --with-apr=/usr/local/apr && make -j 4 && make install
 
 
-ENV LD_LIBRARY_PATH '$LD_LIBRARY_PATH:/usr/local/apr/lib'
 # If a matching Oracle JDK tar.gz exists in /tmp/resources, move it to /var/cache/oracle-jdk8-installer
 # where oracle-java8-installer will detect it
 RUN if ls /tmp/resources/*jdk-*-linux-x64.tar.gz > /dev/null 2>&1; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update
 
 #-------------Application Specific Stuff ----------------------------------------------------
 
-ENV GS_VERSION 2.12.1
+ENV GS_VERSION 2.12.2
 ENV GEOSERVER_DATA_DIR /opt/geoserver/data_dir
 
 ENV GEOSERVER_OPTS "-Djava.awt.headless=true -server -Xms2G -Xmx4G -Xrs -XX:PerfDataSamplingInterval=500 \
@@ -40,7 +40,7 @@ RUN if [ ! -f /tmp/resources/libjpeg-turbo-official_1.5.3_amd64.deb ]; then \
     wget https://tenet.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-official_1.5.3_amd64.deb -P ./resources;\
     fi;
 
-RUN dpkg -i libjpeg-turbo-official_1.5.3_amd64.deb
+RUN dpkg -i /tmp/resources/libjpeg-turbo-official_1.5.3_amd64.deb
 # If a matching Oracle JDK tar.gz exists in /tmp/resources, move it to /var/cache/oracle-jdk8-installer
 # where oracle-java8-installer will detect it
 RUN if ls /tmp/resources/*jdk-*-linux-x64.tar.gz > /dev/null 2>&1; then \
@@ -96,11 +96,11 @@ WORKDIR $CATALINA_HOME
 
 # A little logic that will fetch the geoserver war zip file if it
 # is not available locally in the resources dir
-RUN if [ ! -f /tmp/resources/geoserver.zip ]; then \
+RUN if [ ! -f /tmp/resources/geoserver-${GS_VERSION}.zip ]; then \
     wget -c http://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip \
-      -O /tmp/resources/geoserver.zip; \
+      -O /tmp/resources/geoserver-${GS_VERSION}.zip; \
     fi; \
-    unzip /tmp/resources/geoserver.zip -d /tmp/geoserver \
+    unzip /tmp/resources/geoserver-${GS_VERSION}.zip -d /tmp/geoserver \
     && unzip /tmp/geoserver/geoserver.war -d $CATALINA_HOME/webapps/geoserver \
     && rm -rf $CATALINA_HOME/webapps/geoserver/data \
     && rm -rf /tmp/geoserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ ADD resources /tmp/resources
 # Install libjpeg-turbo for that specific geoserver version
 RUN if [ ! -f /tmp/resources/libjpeg-turbo-official_1.5.3_amd64.deb ]; then \
     wget https://tenet.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-official_1.5.3_amd64.deb -P ./resources;\
-    fi;
-
-RUN dpkg -i /tmp/resources/libjpeg-turbo-official_1.5.3_amd64.deb
+    fi; \
+    cd /tmp/resources/ && \
+    dpkg -i libjpeg-turbo-official_1.5.3_amd64.deb
 
 
 # Install tomcat APR

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN  dpkg-divert --local --rename --add /sbin/initctl
 
 RUN apt-get -y update
 
+#Install extra fonts to use with sld font markers
+RUN apt-get install -y  fonts-cantarell lmodern ttf-aenigma ttf-georgewilliams ttf-bitstream-vera ttf-sjfonts tv-fonts
 #-------------Application Specific Stuff ----------------------------------------------------
 
 ENV GS_VERSION 2.12.1

--- a/README.md
+++ b/README.md
@@ -210,11 +210,15 @@ If you need to use geoserver data directory that contains sample examples and co
 it from geonode site as indicated below:
 
 ```shell
-wget -c http://build.geonode.org/geoserver/latest/data-2.12.x.zip
-unzip data-2.12.x.zip
-mv data ~/geoserver_data
+#!/bin/sh
+# where GS_VERSION is the version of the geoserver installed
+unzip resources/geoserver-${GS_VERSION}.zip -d /tmp/geoserver-${GS_VERSION}
+unzip /tmp/geoserver-${GS_VERSION}/geoserver.war -d /tmp/geoserver-${GS_VERSION}/geoserver
+mv /tmp/geoserver-${GS_VERSION}/geoserver/data ~/geoserver_data
+rm -r  /tmp/geoserver-${GS_VERSION} && cp controlflow.properties ~/geoserver_data
 chmod -R a+rwx ~/geoserver_data
-docker run -d -v $HOME/geoserver_data:/opt/geoserver/data_dir kartoza/geoserver
+docker run -d -p 8580:8080 --name "geoserver" -v $HOME/geoserver_data:/opt/geoserver/data_dir kartoza/geoserver:${GS_VERSION}
+
 ```
 Create an empty data directory to use to persist your data.
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,7 @@ If you don't make changes it will download Oracle Java and various Oracle and Ge
 The  Tomcat properties such as maximum heap memory size are included in the Dockerfile. You need to change them 
 them before building the image in accordance to the resources available on your server:
 
-The default settings in the image are:
-
-```
-ENV GEOSERVER_OPTS "-Djava.awt.headless=true -server -Xms2G -Xmx4G -Xrs -XX:PerfDataSamplingInterval=500 -Dorg.geotools.referencing.forceXY=true -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseParallelGC -XX:NewRatio=2 -XX:+CMSClassUnloadingEnabled"
-
-```
-Where you can change the variables based on [geoserver container considerations](http://docs.geoserver.org/stable/en/user/production/container.html)
+You can change the variables based on [geoserver container considerations](http://docs.geoserver.org/stable/en/user/production/container.html)
 
 To build yourself with a local checkout:
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,33 @@ get our docker trusted build like this:
 docker pull kartoza/geoserver
 ```
 
-To build the image yourself:
+### Pre-downloading files
 
-```shell
-docker build -t kartoza/geoserver git://github.com/kartoza/docker-geoserver
+Inspect downloads.sh to confirm which files you want, then run `.downloads.sh.`
+
+If you don't make changes it will download Oracle Java and various Oracle and Geoserver extensions that will be used during the Docker build. 
+
+### Setting Tomcat properties during build
+
+The  Tomcat properties such as maximum heap memory size are included in the Dockerfile. You need to change them 
+them before building the image in accordance to the resources available on your server:
+
+The default settings in the image are:
+
 ```
+ENV GEOSERVER_OPTS "-Djava.awt.headless=true -server -Xms2G -Xmx4G -Xrs -XX:PerfDataSamplingInterval=500 -Dorg.geotools.referencing.forceXY=true -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseParallelGC -XX:NewRatio=2 -XX:+CMSClassUnloadingEnabled"
+
+```
+Where you can change the variables based on [geoserver container considerations](http://docs.geoserver.org/stable/en/user/production/container.html)
 
 To build yourself with a local checkout:
 
 ```shell
 git clone git://github.com/kartoza/docker-geoserver
-docker build -t kartoza/geoserver .
+cd docker-geoserver
+./build.sh
 ```
+
 
 ### Building with Oracle JDK
 
@@ -191,6 +206,18 @@ automate the process without user intervention.
 
 Docker volumes can be used to persist your data.
 
+If you need to use geoserver data directory that contains sample examples and configurations download
+it from geonode site as indicated below:
+
+```shell
+wget -c http://build.geonode.org/geoserver/latest/data-2.12.x.zip
+unzip data-2.12.x.zip
+mv data ~/geoserver_data
+chmod -R a+rwx ~/geoserver_data
+docker run -d -v $HOME/geoserver_data:/opt/geoserver/data_dir kartoza/geoserver
+```
+Create an empty data directory to use to persist your data.
+
 ```shell
 mkdir -p ~/geoserver_data
 docker run -d -v $HOME/geoserver_data:/opt/geoserver/data_dir kartoza/geoserver
@@ -198,6 +225,11 @@ docker run -d -v $HOME/geoserver_data:/opt/geoserver/data_dir kartoza/geoserver
 
 You need to ensure the ``geoserver_data`` directory has sufficient permissions
 for the docker process to read / write it.
+
+### Control flow properties
+if you have installed the control flow module to manage request in geoserver you need to copy the file
+controlflow.properties to the base of the data directory. You can fine tune the control flow file
+with other parameters as defined in the [documentation](http://docs.geoserver.org/latest/en/user/extensions/controlflow/index.html)
 
 ## Setting Tomcat properties
 
@@ -213,6 +245,7 @@ Then pass the `setenv.sh` file as a volume at `/usr/local/tomcat/bin/setenv.sh` 
 ```shell
 docker run -d -v $HOME/setenv.sh:/usr/local/tomcat/bin/setenv.sh kartoza/geoserver
 ```
+
 
 ## Credits
 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,30 @@
 #!/bin/sh
+# Check the geoserver version specified in the Dockerfile and substitute the number in the globals starting with OLD.
 
-docker build -t kartoza/geoserver .
+## GLOBALS
+# This specifies the current version that is specified in the Dockerfile and download script (the previous stable version if a new stable version is available).
+OLD_BUGFIX=1
+OLD_MINOR=12
+OLD_MAJOR=2
+
+# This represents the version we need geoserver to move up to. ie the lattest stable version
+BUGFIX=12
+MINOR=12
+MAJOR=2
+
+## Prepare to bump geoserver to a specific version
+
+if grep -rl -q "${OLD_MAJOR}.${OLD_MINOR}.${OLD_BUGFIX}" Dockerfile
+
+then
+    echo "found"
+    sed -i "s/${OLD_MAJOR}.${OLD_MINOR}.${OLD_BUGFIX}/${MAJOR}.${MINOR}.${BUGFIX}/g" Dockerfile
+	sed -i "s/${OLD_MAJOR}.${OLD_MINOR}.${OLD_BUGFIX}/${MAJOR}.${MINOR}.${BUGFIX}/g" download.sh
+	./download.sh
+	docker build -t kartoza/geoserver:${MAJOR}.${MINOR}.${BUGFIX} .
+else
+    echo "It seems the geoserver has not been upgraded. We will download the extensions and build geoserver."
+	./download.sh
+	docker build -t kartoza/geoserver:${OLD_MAJOR}.${OLD_MINOR}.${OLD_BUGFIX} .
+fi
+

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ MAJOR=2
 if grep -rl -q "${OLD_MAJOR}.${OLD_MINOR}.${OLD_BUGFIX}" Dockerfile
 
 then
-    echo "found"
+    echo "We are going to upgrade the geoserver version"
     sed -i "s/${OLD_MAJOR}.${OLD_MINOR}.${OLD_BUGFIX}/${MAJOR}.${MINOR}.${BUGFIX}/g" Dockerfile
 	sed -i "s/${OLD_MAJOR}.${OLD_MINOR}.${OLD_BUGFIX}/${MAJOR}.${MINOR}.${BUGFIX}/g" download.sh
 	./download.sh

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ OLD_MINOR=12
 OLD_MAJOR=2
 
 # This represents the version we need geoserver to move up to. ie the lattest stable version
-BUGFIX=12
+BUGFIX=2
 MINOR=12
 MAJOR=2
 

--- a/controlflow.properties
+++ b/controlflow.properties
@@ -1,0 +1,17 @@
+# if a request waits in queue for more than 60 seconds it's not worth executing,
+# the client will  likely have given up by then
+timeout=60
+# don't allow the execution of more than 100 requests total in parallel
+ows.global=100
+# don't allow more than 10 GetMap in parallel
+ows.wms.getmap=10
+# don't allow more than 4 outputs with Excel output as it's memory bound
+ows.wfs.getfeature.application/msexcel=4
+# don't allow a single user to perform more than 6 requests in parallel
+# (6 being the Firefox default concurrency level at the time of writing)
+user=6
+# don't allow the execution of more than 16 tile requests in parallel
+# (assuming a server with 4 cores, GWC empirical tests show that throughput
+# peaks up at 4 x number of cores. Adjust as appropriate to your system)
+ows.gwc=16
+user.ows.wps.execute=1000/d;30s

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Download geoserver extensions and other resources
+pushd resources
+#Java
+#Webupd8
+#wget -c https://launchpad.net/~webupd8team/+archive/ubuntu/java/+files/oracle-java8-installer_8u101+8u101arm-1~webupd8~2.tar.xz
+#Oracle
+#wget -c http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jdk-8u112-linux-x64.tar.gz
+wget -c --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jre-8u161-linux-x64.tar.gz
+#Policy
+wget -c --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -O jce_policy.zip
+
+#JAI
+wget -c http://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz
+
+#JAI Image i/o
+wget -c  http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz
+
+#Geoserver
+VERSION=2.12.1
+
+wget -c http://sourceforge.net/projects/geoserver/files/GeoServer/$VERSION/geoserver-$VERSION-war.zip -O geoserver.zip
+
+# Download libjpeg-turbo
+wget -c https://tenet.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-official_1.5.3_amd64.deb
+
+pushd plugins
+#Extensions
+
+# Vector tiles
+wget -c https://tenet.dl.sourceforge.net/project/geoserver/GeoServer/$VERSION/extensions/geoserver-$VERSION-vectortiles-plugin.zip -O geoserver-$VERSION-vectortiles-plugin.zip
+# CSS styling
+wget -c https://tenet.dl.sourceforge.net/project/geoserver/GeoServer/$VERSION/extensions/geoserver-$VERSION-css-plugin.zip -O geoserver-$VERSION-css-plugin.zip
+
+#CSW
+wget -c https://tenet.dl.sourceforge.net/project/geoserver/GeoServer/$VERSION/extensions/geoserver-$VERSION-csw-plugin.zip -O geoserver-$VERSION-csw-plugin.zip
+# WPS
+wget -c https://tenet.dl.sourceforge.net/project/geoserver/GeoServer/$VERSION/extensions/geoserver-$VERSION-wps-plugin.zip -O geoserver-$VERSION-wps-plugin.zip
+# Printing plugin
+wget -c https://tenet.dl.sourceforge.net/project/geoserver/GeoServer/$VERSION/extensions/geoserver-$VERSION-printing-plugin.zip -O geoserver-$VERSION-printing-plugin.zip
+#libjpeg-turbo
+wget -c https://tenet.dl.sourceforge.net/project/geoserver/GeoServer/$VERSION/extensions/geoserver-$VERSION-libjpeg-turbo-plugin.zip -O geoserver-$VERSION-libjpeg-turbo-plugin.zip
+#Control flow
+wget -c https://sourceforge.net/projects/geoserver/files/GeoServer/$VERSION/extensions/geoserver-$VERSION-control-flow-plugin.zip/download -O geoserver-$VERSION-control-flow-plugin.zip
+#Image pyramid
+wget -c https://sourceforge.net/projects/geoserver/files/GeoServer/$VERSION/extensions/geoserver-$VERSION-pyramid-plugin.zip/download -O geoserver-$VERSION-pyramid-plugin.zip
+#GDAL
+wget -c https://sourceforge.net/projects/geoserver/files/GeoServer/$VERSION/extensions/geoserver-$VERSION-gdal-plugin.zip/download -O geoserver-$VERSION-gdal-plugin.zip
+mkdir gdal
+pushd gdal
+wget -c http://demo.geo-solutions.it/share/github/imageio-ext/releases/1.1.X/1.1.15/native/gdal/gdal-data.zip
+popd
+wget -c http://demo.geo-solutions.it/share/github/imageio-ext/releases/1.1.X/1.1.15/native/gdal/linux/gdal192-Ubuntu12-gcc4.6.3-x86_64.tar.gz
+
+popd
+popd

--- a/download.sh
+++ b/download.sh
@@ -24,6 +24,12 @@ wget -c http://sourceforge.net/projects/geoserver/files/GeoServer/$VERSION/geose
 # Download libjpeg-turbo
 wget -c https://tenet.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-official_1.5.3_amd64.deb
 
+#Download tomcat APR
+wget -c http://mirror.za.web4africa.net/apache//apr/apr-1.6.3.tar.gz
+
+#Download tomcat native
+wget -c http://mirror.za.web4africa.net/apache/tomcat/tomcat-connectors/native/1.2.16/source/tomcat-native-1.2.16-src.tar.gz
+
 pushd plugins
 #Extensions
 

--- a/download.sh
+++ b/download.sh
@@ -19,7 +19,7 @@ wget -c  http://download.java.net/media/jai-imageio/builds/release/1.1/jai_image
 #Geoserver
 VERSION=2.12.1
 
-wget -c http://sourceforge.net/projects/geoserver/files/GeoServer/$VERSION/geoserver-$VERSION-war.zip -O geoserver.zip
+wget -c http://sourceforge.net/projects/geoserver/files/GeoServer/$VERSION/geoserver-$VERSION-war.zip -O geoserver-${VERSION}.zip
 
 # Download libjpeg-turbo
 wget -c https://tenet.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-official_1.5.3_amd64.deb

--- a/resources/plugins/README.txt
+++ b/resources/plugins/README.txt
@@ -1,2 +1,0 @@
-Download plugin zips and place them here when building to include them in
-the container's GeoServer deployment.


### PR DESCRIPTION
* Added a download script to install plugins in Geoserver. The script should be run before building the image. Some common plugins should be preinstalled in the image (ie control-flow, GDAL, WPS, Image pyramid)
* Added GDAL data directory and environment variables to ensure when a user installs the Gdal plugins Geoserver recognizes them.
* Moved the java environment settings to the docker file so that the image contains built-in optimizations.
* Modified build script so that when building the image locally you only specify the GeoServer version once in the download script and it changes all occurrences in other files. Example Dockerfile and download.sh.
* Added more instructions in the readme including how to use a persistent storage with sample data from GeoServer war file.
* Added a sample file for use with the control flow module.
* Install libjpeg-turbo- An extension which provides a significant performance enhancement for JPEG encoding in GeoServer WMS output
* Install extra fonts which are used by SLD with graphic markers
