### PR TITLE
fix Jia image io setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENV JAVA_DEBIAN_VERSION=
 RUN ln -s /usr/lib/jvm/java-8-openjdk-amd64 /usr/lib/jvm/default-java
 ENV JAVA_HOME /usr/lib/jvm/default-java
 ARG ORACLE_JDK=false
+ARG JAI_IMAGEIO=false
 ARG TOMCAT_EXTRAS=true
 ARG COMMUNITY_MODULES=true
 
@@ -44,6 +45,7 @@ ARG COMMUNITY_MODULES=true
 WORKDIR /tmp/
 ADD resources /tmp/resources
 ADD setup.sh /
+ADD setup_jia_imageio.sh /
 RUN chmod +x /*.sh
 RUN /setup.sh
 ADD controlflow.properties $GEOSERVER_DATA_DIR

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,7 @@ docker build --build-arg GS_VERSION=${MAJOR}.${MINOR}.${BUGFIX} -t kartoza/geose
 #need to specify a different value.
 ```
 --build-arg ORACLE_JDK=true
+--build-arg JAI_IMAGEIO=true
 --build-arg COMMUNITY_MODULES=true
 --build-arg TOMCAT_EXTRAS=false
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -146,25 +146,31 @@ if ls /var/cache/oracle-jdk8-installer/*jdk-*-linux-x64.tar.gz > /dev/null 2>&1 
          mv /tmp/jce_policy/*.jar $JAVA_HOME/jre/lib/security/; \
        fi; \
     fi;
+# NOTE: I don't know why the following section not working
+#  if [ ! -f /tmp/resources/jai-1_1_3-lib-linux-amd64.tar.gz ]; then \
+#     wget http://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz -P /tmp/resources;\
+#     fi; \
+#     if [ ! -f /tmp/resources/jai_imageio-1_1-lib-linux-amd64.tar.gz ]; then \
+#     wget http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz -P /tmp/resources;\
+#     fi; \
+#     mv resources/jai-1_1_3-lib-linux-amd64.tar.gz ./ && \
+#     mv resources/jai_imageio-1_1-lib-linux-amd64.tar.gz ./ && \
+#     gunzip -c jai-1_1_3-lib-linux-amd64.tar.gz | tar xf - && \
+#     gunzip -c jai_imageio-1_1-lib-linux-amd64.tar.gz | tar xf - && \
+#     mv /tmp/jai-1_1_3/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
+#     mv /tmp/jai-1_1_3/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
+#     mv /tmp/jai_imageio-1_1/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
+#     mv /tmp/jai_imageio-1_1/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
+#     rm /tmp/jai-1_1_3-lib-linux-amd64.tar.gz && \
+#     rm -r /tmp/jai-1_1_3 && \
+#     rm /tmp/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
+#     rm -r /tmp/jai_imageio-1_1
 
- if [ ! -f /tmp/resources/jai-1_1_3-lib-linux-amd64.tar.gz ]; then \
-    wget http://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz -P /tmp/resources;\
-    fi; \
-    if [ ! -f /tmp/resources/jai_imageio-1_1-lib-linux-amd64.tar.gz ]; then \
-    wget http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz -P /tmp/resources;\
-    fi; \
-    mv resources/jai-1_1_3-lib-linux-amd64.tar.gz ./ && \
-    mv resources/jai_imageio-1_1-lib-linux-amd64.tar.gz ./ && \
-    gunzip -c jai-1_1_3-lib-linux-amd64.tar.gz | tar xf - && \
-    gunzip -c jai_imageio-1_1-lib-linux-amd64.tar.gz | tar xf - && \
-    mv /tmp/jai-1_1_3/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
-    mv /tmp/jai-1_1_3/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
-    mv /tmp/jai_imageio-1_1/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
-    mv /tmp/jai_imageio-1_1/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
-    rm /tmp/jai-1_1_3-lib-linux-amd64.tar.gz && \
-    rm -r /tmp/jai-1_1_3 && \
-    rm /tmp/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
-    rm -r /tmp/jai_imageio-1_1
+# Note: I followed the instuction from official geoserver docs http://docs.geoserver.org/stable/en/user/production/java.html
+if [ "$JAI_IMAGEIO" = true ]; then \
+    /setup_jia_imageio.sh
+fi
+
 
 WORKDIR $CATALINA_HOME
 

--- a/setup_jia_imageio.sh
+++ b/setup_jia_imageio.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+cd $JAVA_HOME && \
+wget http://data.opengeo.org/suite/jai/jai-1_1_3-lib-linux-amd64-jdk.bin && \
+echo "yes" | sh jai-1_1_3-lib-linux-amd64-jdk.bin && \
+rm jai-1_1_3-lib-linux-amd64-jdk.bin
+
+cd $JAVA_HOME && \
+export _POSIX2_VERSION=199209 &&\
+wget http://data.opengeo.org/suite/jai/jai_imageio-1_1-lib-linux-amd64-jdk.bin && \
+echo "yes" | sh jai_imageio-1_1-lib-linux-amd64-jdk.bin && \
+rm jai_imageio-1_1-lib-linux-amd64-jdk.bin


### PR DESCRIPTION
This PR fix `Jia_imageio` setup according to Official [Geoserver docs](http://docs.geoserver.org/stable/en/user/production/java.html#installing-native-jai-on-linux)

NOTE:  
- I don't know why the following setup not working (current version on master):
```
 if [ ! -f /tmp/resources/jai-1_1_3-lib-linux-amd64.tar.gz ]; then \
    wget http://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz -P /tmp/resources;\
    fi; \
    if [ ! -f /tmp/resources/jai_imageio-1_1-lib-linux-amd64.tar.gz ]; then \
    wget http://download.java.net/media/jai-imageio/builds/release/1.1/jai_imageio-1_1-lib-linux-amd64.tar.gz -P /tmp/resources;\
    fi; \
    mv resources/jai-1_1_3-lib-linux-amd64.tar.gz ./ && \
    mv resources/jai_imageio-1_1-lib-linux-amd64.tar.gz ./ && \
    gunzip -c jai-1_1_3-lib-linux-amd64.tar.gz | tar xf - && \
    gunzip -c jai_imageio-1_1-lib-linux-amd64.tar.gz | tar xf - && \
    mv /tmp/jai-1_1_3/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
    mv /tmp/jai-1_1_3/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
    mv /tmp/jai_imageio-1_1/lib/*.jar $JAVA_HOME/jre/lib/ext/ && \
    mv /tmp/jai_imageio-1_1/lib/*.so $JAVA_HOME/jre/lib/amd64/ && \
    rm /tmp/jai-1_1_3-lib-linux-amd64.tar.gz && \
    rm -r /tmp/jai-1_1_3 && \
    rm /tmp/jai_imageio-1_1-lib-linux-amd64.tar.gz && \
    rm -r /tmp/jai_imageio-1_1
```
 - screenshot from my geoserver after updating `setup.sh`
![screen shot 2018-08-15 at 4 14 19 pm](https://user-images.githubusercontent.com/24391550/44152696-7c4b528c-a0a6-11e8-9416-d68ec53ce09d.png)
