### PR TITLE
Fix problems arising from hardcoded jasypt path

### DIFF
--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -14,7 +14,7 @@ CLASSPATH=${CLASSPATH:-/usr/local/tomcat/webapps/geoserver/WEB-INF/lib/}
 
 make_hash(){
     NEW_PASSWORD=$1
-    (echo "digest1:" && java -classpath ${CLASSPATH}jasypt-1.8.jar org.jasypt.intf.cli.JasyptStringDigestCLI digest.sh algorithm=SHA-256 saltSizeBytes=16 iterations=100000 input="$NEW_PASSWORD" verbose=0) | tr -d '\n'
+    (echo "digest1:" && java -classpath $(find $CLASSPATH -regex ".*jasypt-[0-9]\.[0-9]\.[0-9].*jar") org.jasypt.intf.cli.JasyptStringDigestCLI digest.sh algorithm=SHA-256 saltSizeBytes=16 iterations=100000 input="$NEW_PASSWORD" verbose=0) | tr -d '\n'
 }
 
 PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD)


### PR DESCRIPTION
When re-building the image with a newer Geoserver version, the `update_passwords.sh` script might fail, because the new Geoserver version uses a newer version of jasypt.

This PR fixes that, by not hardcoding the jasypt jar to 1.8, but instead looking for any jasypt jar located in `$CLASSPATH`.