### PR TITLE
bug fix: update_passwords ignores env data_dir

### DIFF
--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -19,7 +19,7 @@ fi
 
 GEOSERVER_ADMIN_USER=${GEOSERVER_ADMIN_USER:-admin}
 GEOSERVER_ADMIN_PASSWORD=${GEOSERVER_ADMIN_PASSWORD:-geoserver}
-USERS_XML=${USERS_XML:-/opt/geoserver/data_dir/security/usergroup/default/users.xml}
+USERS_XML=${USERS_XML:-${GEOSERVER_DATA_DIR}/security/usergroup/default/users.xml}
 CLASSPATH=${CLASSPATH:-/usr/local/tomcat/webapps/geoserver/WEB-INF/lib/}
 
 make_hash(){


### PR DESCRIPTION
unpatched causes error:
```
svc-geoserver_1  | cp: cannot stat '/opt/geoserver/data_dir/security/usergroup/default/users.xml': No such file or directory
svc-geoserver_1  | /scripts/update_passwords.sh: line 35: /opt/geoserver/data_dir/security/usergroup/default/users.xml: No such file or directory
svc-geoserver_1  | cat: /opt/geoserver/data_dir/security/usergroup/default/users.xml.orig: No such file or directory
```