### PR TITLE
Add GEOSERVER_CSRF_WHITELIST to geoserver.env

### DIFF
--- a/docker-env/geoserver.env
+++ b/docker-env/geoserver.env
@@ -5,5 +5,6 @@ OPTIMIZE_LINE_WIDTH=false
 FOOTPRINTS_DATA_DIR=/opt/footprints_dir
 GEOWEBCACHE_CACHE_DIR=/opt/geoserver/data_dir/gwc
 GEOSERVER_ADMIN_PASSWORD=myawesomegeoserver
+GEOSERVER_CSRF_WHITELIST=myawesomedomain.com
 INITIAL_MEMORY=2G
 MAXIMUM_MEMORY=4G


### PR DESCRIPTION
When having geoserver behind a proxy (such as nginx). The need to have that domain added to the CSRF whitelist is necessary for all of the
forms to work when POSTing data back to geoserver. Geoserver offers the
GEOSERVER_CSRF_WHITELIST property to be set via web.xml, -D arg via JVM,
or by environment variable. Since this is a containerized version of geoserver,
using an environment variable is optimal for following cloud native
development best practices (aka 12-factor).

Reference: https://docs.geoserver.org/stable/en/user/security/webadmin/csrf.html