### PR TITLE
Added option for EXISTING_DATA_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ create the file at `resources/overlays/usr/local/tomcat/bin/setenv.sh`.
 You can use this functionality to write a static GeoServer directory to
 `/opt/geoserver/data_dir`, include additional jar files, and more.
 
+If you have an already existing `data_dir` with a security setup from another Geoserver: set `EXISTING_DATA_DIR=true`.
+This will keep the passwords from getting changed by docker. 
+
 Overlay files will overwrite existing destination files, so be careful!
+
 
 #### Build with CORS Support
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -40,5 +40,8 @@ export GEOSERVER_OPTS="-Djava.awt.headless=true -server -Xms${INITIAL_MEMORY} -X
 ## Preparare the JVM command line arguments
 export JAVA_OPTS="${JAVA_OPTS} ${GEOSERVER_OPTS}"
 
-/scripts/update_passwords.sh
+## Run update_passwords if not using an existing data_dir
+if [[ -z "${EXISTING_DATA_DIR}" ]]; then \
+    /scripts/update_passwords.sh
+fi;
 exec /usr/local/tomcat/bin/catalina.sh run


### PR DESCRIPTION
Fixes #127 by not running `update_passwords.sh` if the environment variable EXISTING_DATA_DIR is set. 