### PR TITLE
Edit the roles.xml file to have the custom geoserver admin user set as an admin

### DIFF
--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -20,6 +20,7 @@ fi
 GEOSERVER_ADMIN_USER=${GEOSERVER_ADMIN_USER:-admin}
 GEOSERVER_ADMIN_PASSWORD=${GEOSERVER_ADMIN_PASSWORD:-geoserver}
 USERS_XML=${USERS_XML:-${GEOSERVER_DATA_DIR}/security/usergroup/default/users.xml}
+ROLES_XML=${ROLES_XML:-${GEOSERVER_DATA_DIR}/security/role/default/roles.xml}
 CLASSPATH=${CLASSPATH:-/usr/local/tomcat/webapps/geoserver/WEB-INF/lib/}
 
 make_hash(){
@@ -28,11 +29,16 @@ make_hash(){
 }
 
 PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD)
+
+# users.xml setup
 cp $USERS_XML $USERS_XML.orig
-
 # <user enabled="true" name="admin" password="digest1:7/qC5lIvXIcOKcoQcCyQmPK8NCpsvbj6PcS/r3S7zqDEsIuBe731ZwpTtcSe9IiK"/>
-
 cat $USERS_XML.orig | sed -e "s/ name=\".*\" / name=\"${GEOSERVER_ADMIN_USER}\" /" | sed -e "s/ password=\".*\"/ password=\"${PWD_HASH//\//\\/}\"/" > $USERS_XML
+
+# roles.xml setup
+cp $ROLES_XML $ROLES_XML.orig
+# <userRoles username="admin">
+cat $ROLES_XML.orig | sed -e "s/ username=\".*\"/ username=\"${GEOSERVER_ADMIN_USER}\"/" > $ROLES_XML
 
 # Put lock file to make sure password is not reinitialized on restart
 touch ${SETUP_LOCKFILE}


### PR DESCRIPTION
Minor changes to the update_passwords.sh script to handle setting a custom admin username as an admin in geoserver. Regarding issue: #148 