### PR TITLE
Add support for Tomcat/9.0.36 #165

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 #--------- Generic stuff all our Dockerfiles should start with so we get caching ------------
 ARG IMAGE_VERSION=9-jre11-slim
 
+ARG JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 FROM tomcat:$IMAGE_VERSION
 
@@ -22,14 +23,12 @@ RUN wget http://ftp.br.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscore
 RUN set -e \
     export DEBIAN_FRONTEND=noninteractive \
     dpkg-divert --local --rename --add /sbin/initctl \
-    # Set JAVA_HOME to /usr/lib/jvm/default-java and link it to OpenJDK installation
-    && ln -s /usr/lib/jvm/java-11-openjdk-amd64 /usr/lib/jvm/default-java \
     && (echo "Yes, do as I say!" | apt-get remove --force-yes login) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 ENV \
-    JAVA_HOME=/usr/lib/jvm/default-java \
+    JAVA_HOME=${JAVA_HOME} \
     STABLE_EXTENSIONS='' \
     COMMUNITY_EXTENSIONS='' \
     DEBIAN_FRONTEND=noninteractive \
@@ -73,7 +72,9 @@ RUN mkdir /community_plugins /stable_plugins /plugins
 RUN cp /build_data/stable_plugins.txt /plugins && cp /build_data/community_plugins.txt /community_plugins && \
     cp /build_data/log4j.properties  ${CATALINA_HOME} && cp /build_data/web.xml ${CATALINA_HOME}/conf && \
     cp /build_data/letsencrypt-tomcat.xsl ${CATALINA_HOME}/conf && \
-    cp /build_data/tomcat-users.xml /usr/local/tomcat/conf && \
+    cp /build_data/tomcat-users.xml /usr/local/tomcat/conf
+
+RUN if [ -d $CATALINA_HOME/webapps.dist/manager ]; then cp -avT $CATALINA_HOME/webapps.dist/manager $CATALINA_HOME/webapps/manager; fi &&\
     cp /build_data/context.xml /usr/local/tomcat/webapps/manager/META-INF
 
 ADD scripts /scripts

--- a/README.md
+++ b/README.md
@@ -56,8 +56,13 @@ To build using a specific tagged release for tomcat image set the
 to choose which tag you need to build against.
 
 ```
-ie VERSION=2.16.2
-docker build --build-arg IMAGE_VERSION=8-jre8 --build-arg GS_VERSION=2.13.0 -t kartoza/geoserver:${VERSION} .
+ie VERSION=2.17.0
+docker build --build-arg IMAGE_VERSION=8-jre8 --build-arg GS_VERSION=2.17.0 -t kartoza/geoserver:${VERSION} .
+```
+
+For some recent builds it is necessary to set the JAVA_PATH as well (e.g. Apache Tomcat/9.0.36)
+```
+docker build --build-arg IMAGE_VERSION=9-jdk11-openjdk-slim --build-arg JAVA_HOME=/usr/local/openjdk-11/bin/java --build-arg GS_VERSION=2.17.0 -t kartoza/geoserver:2.17.0 .
 ```
 
 ### Building with file system overlays (advanced)


### PR DESCRIPTION
This is to support 9.0.36 without breaking earlier versions. I have moved definition of JAVA_HOME to an argument of the docker container. If webapps/manager is in the dist folder, it is copied across.