### PR TITLE
Changes required to make this image work on openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,16 +124,19 @@ ENV \
 
 EXPOSE  $HTTPS_PORT
 
-RUN groupadd -r geoserverusers -g 10001 && \
-    useradd -m -d /home/geoserveruser/ --gid 10001 -s /bin/bash -G geoserverusers geoserveruser
-RUN chown -R geoserveruser:geoserverusers ${CATALINA_HOME} ${FOOTPRINTS_DATA_DIR}  \
- ${GEOSERVER_DATA_DIR} /scripts ${LETSENCRYPT_CERT_DIR} ${FONTS_DIR} /tmp/ /home/geoserveruser/ /community_plugins/ \
- /plugins
+RUN chmod g=u /etc/passwd && mkdir -p /home/geoserveruser
+
+
+RUN chgrp -R 0 ${CATALINA_HOME} ${FOOTPRINTS_DATA_DIR} \
+    ${GEOSERVER_DATA_DIR} /scripts ${LETSENCRYPT_CERT_DIR} ${FONTS_DIR} /tmp/ /home/geoserveruser/ /community_plugins/ /plugins && \
+    chmod -R g=u ${CATALINA_HOME} ${FOOTPRINTS_DATA_DIR} \
+    ${GEOSERVER_DATA_DIR} /scripts ${LETSENCRYPT_CERT_DIR} ${FONTS_DIR} /tmp/ /home/geoserveruser/ /community_plugins/ /plugins
 
 RUN chmod o+rw ${LETSENCRYPT_CERT_DIR}
 
-USER geoserveruser
 VOLUME ["${GEOSERVER_DATA_DIR}", "${LETSENCRYPT_CERT_DIR}", "${FOOTPRINTS_DATA_DIR}", "${FONTS_DIR}", "${GEOWEBCACHE_CACHE_DIR}"]
 WORKDIR ${CATALINA_HOME}
+
+USER 1001
 
 CMD ["/bin/sh", "/scripts/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+/scripts/openshift_entrypoint.sh
+
 /scripts/start.sh
 
 CLUSTER_CONFIG_DIR="${GEOSERVER_DATA_DIR}/cluster/instance_$RANDOMSTRING"

--- a/scripts/entrypoint_openshift.sh
+++ b/scripts/entrypoint_openshift.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export USER_NAME=geoserveruser
+export HOME=/home/geoserveruser
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+cd $HOME


### PR DESCRIPTION
Hello, we needed a geoserver image that could run on openshift. I couldn't get the plain image to run on openshift because you don't know the user that will be running the services inside the container. Images running on open shift need to follow these guidelines: https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html

This pull request covers what is necessary to get it to work (tested on our local openshift platform).

Thank you for this repo!

Thanks to @kervel for the help!