### PR TITLE
Allow environment variables to be set from Docker secret files (similar to kartoza/docker-postgis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,18 @@ GEOSERVER_ADMIN_PASSWORD and GEOSERVER_ADMIN_USER to  change it on runtime.
 docker run --name "geoserver" -e GEOSERVER_ADMIN_USER=kartoza  -e GEOSERVER_ADMIN_PASSWORD=myawesomegeoserver -p 8080:8080 -d -t kartoza/geoserver
 ```
 
+#### Docker secrets
+
+To avoid passing sensitive information in environment variables, `_FILE` can be appended to
+some of the variables to read from files present in the container. This is particularly useful
+in conjunction with Docker secrets, as passwords can be loaded from `/run/secrets/<secret_name>` e.g.:
+
+* -e GEOSERVER_ADMIN_PASSWORD_FILE=/run/secrets/<geoserver_pass_secret>
+
+For more information see [https://docs.docker.com/engine/swarm/secrets/](https://docs.docker.com/engine/swarm/secrets/).
+
+Currently, `GEOSERVER_ADMIN_USER` and `GEOSERVER_ADMIN_PASSWORD` are supported.
+
 ## Clustering using JMS Plugin
 GeoServer supports clustering using JMS cluster plugin or using the ActiveMQ-broker. 
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /scripts/env-data.sh
+
 /scripts/start.sh
 
 CLUSTER_CONFIG_DIR="${GEOSERVER_DATA_DIR}/cluster/instance_$RANDOMSTRING"

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Read data from secrets into env variables.
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+function file_env {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'GEOSERVER_ADMIN_USER'
+file_env 'GEOSERVER_ADMIN_PASSWORD'


### PR DESCRIPTION
We have found that sometimes some of the environment variables set to get GeoServer running have sensitive information in them like credentials or passwords. Having a way to set those environment variables from Docker secret files can be helpful. This code follows a pattern we found in another kartoza GitHub repository kartoza/docker-postgis.