### PR TITLE
Allow specifying arbitrary UID/GID for geoserveruser

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,8 @@ JAVA_HOME=/usr/local/openjdk-11
 WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/2.18.2/geoserver-2.18.2-war.zip
 ACTIVATE_ALL_STABLE_EXTENTIONS=1
 ACTIVATE_ALL_COMMUNITY_EXTENTIONS=1
+GEOSERVERUSER_UID=1000
+GEOSERVERUSERS_GID=10001
 
 # Generic Env variables
 GEOSERVER_ADMIN_USER=admin

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ARG GS_VERSION=2.18.2
 ARG WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
 ARG ACTIVATE_ALL_STABLE_EXTENTIONS=1
 ARG ACTIVATE_ALL_COMMUNITY_EXTENTIONS=1
+ARG GEOSERVER_UID=1000
+ARG GEOSERVER_GID=10001
 
 #Install extra fonts to use with sld font markers
 RUN apt-get -y update; apt-get install -y fonts-cantarell lmodern ttf-aenigma ttf-georgewilliams ttf-bitstream-vera \
@@ -125,8 +127,8 @@ ENV \
 
 EXPOSE  $HTTPS_PORT
 
-RUN groupadd -r geoserverusers -g 10001 && \
-    useradd -m -d /home/geoserveruser/ --gid 10001 -s /bin/bash -G geoserverusers geoserveruser
+RUN groupadd -r geoserverusers -g ${GEOSERVER_GID} && \
+    useradd -m -d /home/geoserveruser/ -u ${GEOSERVER_UID} --gid ${GEOSERVER_GID} -s /bin/bash -G geoserverusers geoserveruser
 RUN chown -R geoserveruser:geoserverusers ${CATALINA_HOME} ${FOOTPRINTS_DATA_DIR}  \
  ${GEOSERVER_DATA_DIR} /scripts ${LETSENCRYPT_CERT_DIR} ${FONTS_DIR} /tmp/ /home/geoserveruser/ /community_plugins/ \
  /plugins

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ WAR_URL= Default URL to fetch geoserver war or zip file
 STABLE_PLUGIN_URL= URL to fetch geoserver plugins
 ACTIVATE_ALL_STABLE_EXTENTIONS= Specifies whether to build all stable plugins or a single one
 ACTIVATE_ALL_COMMUNITY_EXTENTIONS=Specifies whether to build all community plugins or a single one
+GEOSERVER_UID=Specifies the uid to use for the user used to run GeoServer in the container
+GEOSERVER_GID=Specifies the gid to use for the group used to run GeoServer in the container
 ```
 
 ```shell


### PR DESCRIPTION
Allow specifying arbitrary UID/GID for geoserveruser as some existing geoserver data dirs might have existing uid/gid ownership that can't be changed.