### PR TITLE
stable_plugins: add csw-plugin, needed for csw-iso-plugin in community_plugins.txt

### DIFF
--- a/build_data/stable_plugins.txt
+++ b/build_data/stable_plugins.txt
@@ -3,6 +3,7 @@ authkey-plugin
 cas-plugin
 charts-plugin
 css-plugin
+csw-plugin
 db2-plugin
 dxf-plugin
 excel-plugin


### PR DESCRIPTION
From
https://github.com/geoserver/geoserver/blob/770dc6f7023bc2ab32597cfc7a3a9cc35ff3b608/doc/en/user/source/community/csw-iso/installing.rst
it seems both of these plugins have to be together.

Tested a local docker build, the new `csw-plugin` is being downloaded properly during the build:
```
URL exists: https://liquidtelecom.dl.sourceforge.net/project/geoserver/GeoServer/2.18.2/extensions/geoserver-2.18.2-csw-plugin.zip                   
--2021-03-24 13:59:40--  https://liquidtelecom.dl.sourceforge.net/project/geoserver/GeoServer/2.18.2/extensions/geoserver-2.18.2-csw-plugin.zip       
Resolving liquidtelecom.dl.sourceforge.net (liquidtelecom.dl.sourceforge.net)... 197.155.77.8                                                       
Connecting to liquidtelecom.dl.sourceforge.net (liquidtelecom.dl.sourceforge.net)|197.155.77.8|:443... connected.                                     
HTTP request sent, awaiting response... 200 OK                                                                                                      
Length: 933111 (911K) [application/octet-stream]                                                                                                      
Saving to: ‘csw-plugin.zip’                                                                                                                     
                                                                                                                                                      
csw-plugin.zip      100%[===================>] 911.24K   738KB/s    in 1.2s                                                                           

2021-03-24 13:59:43 (738 KB/s) - ‘csw-plugin.zip’ saved [933111/933111]
```

Also just would like to say thanks for maintaining this.  We upgraded from `2.9.3` to `2.18.2` and it feels like a massive improvements, see https://github.com/bird-house/birdhouse-deploy/pull/136