### PR TITLE
Pin tomcat image tag to tomcat 9

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 COMPOSE_PROJECT_NAME=kartozageoserver
 
-IMAGE_VERSION=jdk11-openjdk-slim-buster
+IMAGE_VERSION=9.0-jdk11-openjdk-slim-buster
 GS_VERSION=2.19.2
 GEOSERVER_PORT=8600
 # Build Arguments

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #--------- Generic stuff all our Dockerfiles should start with so we get caching ------------
-ARG IMAGE_VERSION=jdk11-openjdk-slim-buster
+ARG IMAGE_VERSION=9.0-jdk11-openjdk-slim-buster
 ARG JAVA_HOME=/usr/local/openjdk-11
 FROM tomcat:$IMAGE_VERSION
 


### PR DESCRIPTION
Currently the `IMAGE_TAG` variable in the Dockerfile and .env file are set to 'jdk11-openjdk-slim-buster'
The Tomcat docker image maintainers updated that tag to Tomcat 10, which is breaking this build process (see https://github.com/kartoza/docker-geoserver/issues/301#issuecomment-922669052)

This PR pins the tomcat tag to Tomcat 9 in order to avoid breaking the build process when the tomcat version changes for a tag.

I purposely made this pr against the master branch in order to patch the broken build process. If necessary I can recreate it against the develop branch.