### PR TITLE
282 Remove Volume definition in Dockerfile and apply persistent behaviour to docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ EXPOSE  $HTTPS_PORT
 
 USER ${GEOSERVER_UID}
 RUN echo 'figlet -t "Kartoza Docker GeoServer"' >> ~/.bashrc
-VOLUME ["${GEOSERVER_DATA_DIR}", "${CERT_DIR}", "${FOOTPRINTS_DATA_DIR}", "${FONTS_DIR}"]
+
 WORKDIR ${GEOSERVER_HOME}
 
 CMD ["/bin/bash", "/scripts/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       image: kartoza/geoserver:${GS_VERSION}
       volumes:
         - geoserver-data:/opt/geoserver/data_dir
+        - geoserver-data:/etc/certs
+        - geoserver-data:/opt/footprints_dir
+        - geoserver-data:/opt/fonts
       ports:
         - ${GEOSERVER_PORT}:8080
       restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,6 @@ services:
       image: kartoza/geoserver:${GS_VERSION}
       volumes:
         - geoserver-data:/opt/geoserver/data_dir
-        - geoserver-data:/etc/certs
-        - geoserver-data:/opt/footprints_dir
-        - geoserver-data:/opt/fonts
       ports:
         - ${GEOSERVER_PORT}:8080
       restart: on-failure


### PR DESCRIPTION
This Pull Request closes #282. It makes sure that no `VOLUME` is defined inside of the Dockerfile so that the user of this image has full control over how they want to define persistency in their Geoserver stack. 

This makes it possible for someone to allow persistency at built vs persistency at runtime (see the ticket for a better explanation). 

----

I changed the docker-compose to have the same behaviour as the `VOLUME` did. As this docker-compose is just a suggestion for someone using this image, I do not believe this is that important.