### PR TITLE
Set the username / password of the Geoserver's admin user via env variables - fix

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,6 +8,7 @@ source /scripts/functions.sh
 source /scripts/env-data.sh
 
 /bin/bash /scripts/start.sh
+/bin/bash /scripts/update_passwords.sh
 
 
 RANDOMSTRING=$(cat /scripts/.pass_14.txt)

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -260,7 +260,7 @@ function geoserver_logging() {
 function file_env {
 	local var="$1"
 	local fileVar="${var}_FILE"
-	local def="${2:-}"
+	local def="${1:-}"
 	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
 		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
 		exit 1


### PR DESCRIPTION
#### Reference issue

https://github.com/kartoza/docker-geoserver/issues/326

#### Description

Set the username / password of the Geoserver's admin user from the enviroment variables `GEOSERVER_ADMIN_USER` and `GEOSERVER_ADMIN_PASSWORD` (or `GEOSERVER_ADMIN_PASSWORD_FILE`).

Docker image tag: `kartoza/geoserver:2.20.0`
Deployment environment: `kubernetes`