### PR TITLE
Update Geoserver to 2.20.2 for CVE-2021-44228 and CVE-2019-17571

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,11 @@
 COMPOSE_PROJECT_NAME=kartozageoserver
 
 IMAGE_VERSION=9.0-jdk11-openjdk-slim-buster
-GS_VERSION=2.20.1
+GS_VERSION=2.20.2
 GEOSERVER_PORT=8600
 # Build Arguments
 JAVA_HOME=/usr/local/openjdk-11
-WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/2.20.1/geoserver-2.20.1-war.zip
+WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/2.20.2/geoserver-2.20.2-war.zip
 DOWNLOAD_ALL_STABLE_EXTENSIONS=1
 DOWNLOAD_ALL_COMMUNITY_EXTENSIONS=1
 GEOSERVERUSER_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG JAVA_HOME=/usr/local/openjdk-11
 FROM tomcat:$IMAGE_VERSION
 
 LABEL maintainer="Tim Sutton<tim@linfiniti.com>"
-ARG GS_VERSION=2.20.1
+ARG GS_VERSION=2.20.2
 ARG WAR_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
 ARG DOWNLOAD_ALL_STABLE_EXTENSIONS=1
 ARG DOWNLOAD_ALL_COMMUNITY_EXTENSIONS=1

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The preferred way (but using most bandwidth for the initial image) is to
 get our docker trusted build like this:
 
 ```shell
-VERSION=2.20.0
+VERSION=2.20.2
 docker pull kartoza/geoserver:$VERSION
 ```
 ### Building the image
@@ -94,7 +94,7 @@ To build using a specific tagged release for tomcat image set the
 to choose which tag you need to build against.
 
 ```
-ie VERSION=2.20.0
+ie VERSION=2.17.0
 docker build --build-arg IMAGE_VERSION=8-jre8 --build-arg GS_VERSION=2.17.0 -t kartoza/geoserver:${VERSION} .
 ```
 
@@ -124,7 +124,7 @@ The image ships with the following stable plugins:
 * csw-plugin
 
 **Note:** The plugins listed above are omitted from [Stable_plugins.txt](https://github.com/kartoza/docker-geoserver/blob/master/build_data/stable_plugins.txt)
-even though they are considered [stable plugins](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.0/extensions/)
+even though they are considered [stable plugins](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.2/extensions/)
 The image activates them on startup.
 
 The image provides the necessary plugin zip files which are used when activating the
@@ -142,7 +142,7 @@ The environment variable `STABLE_EXTENSIONS` can be used to activate plugins lis
 Example
 
 ```
-ie VERSION=2.20.0
+ie VERSION=2.20.2
 docker run -d -p 8600:8080 --name geoserver -e STABLE_EXTENSIONS=charts-plugin,db2-plugin kartoza/geoserver:${VERSION} 
 
 ```
@@ -163,7 +163,7 @@ The environment variable `COMMUNITY_EXTENSIONS` can be used to activate plugins 
 Example 
 
 ``` 
-ie VERSION=2.20.0
+ie VERSION=2.20.2
 docker run -d -p 8600:8080 --name geoserver -e COMMUNITY_EXTENSIONS=gwc-sqlite-plugin,ogr-datastore-plugin kartoza/geoserver:${VERSION} 
 
 ```
@@ -178,7 +178,7 @@ Geoserver ships with sample data which can be used by users to familiarize them 
 This is not activated by default. You can activate it using the environment variable `SAMPLE_DATA=true` 
 
 ``` 
-ie VERSION=2.20.0
+ie VERSION=2.20.2
 docker run -d -p 8600:8080 --name geoserver -e SAMPLE_DATA=true kartoza/geoserver:${VERSION} 
 
 ```
@@ -253,14 +253,14 @@ If you set the environment variable `SSL=true` but do not provide the pem files 
 the container will generate a self signed SSL certificates.
 
 ```
-ie VERSION=2.20.0
+ie VERSION=2.20.2
 docker run -it --name geoserver  -e PKCS12_PASSWORD=geoserver -e JKS_KEY_PASSWORD=geoserver -e JKS_STORE_PASSWORD=geoserver -e SSL=true -p 8443:8443 -p 8600:8080 kartoza/geoserver:${VERSION} 
 ```
 
 If you already have your perm files (fullchain.pem and privkey.pem) you can mount the directory containing your keys as:
 
 ``` 
-ie VERSION=2.20.0
+ie VERSION=2.20.2
 docker run -it --name geo -v /etc/certs:/etc/certs  -e PKCS12_PASSWORD=geoserver -e JKS_KEY_PASSWORD=geoserver -e JKS_STORE_PASSWORD=geoserver -e SSL=true -p 8443:8443 -p 8600:8080 kartoza/geoserver:${VERSION}  
 
 ```
@@ -322,7 +322,7 @@ To include Tomcat extras including docs, examples, and the manager webapp, set t
 to use a strong password otherwise the default one is set up.
 
 ```
-ie VERSION=2.20.0
+ie VERSION=2.20.2
 docker run -it --name geoserver  -e TOMCAT_EXTRAS=true -p 8600:8080 kartoza/geoserver:${VERSION} 
 ```
 
@@ -342,7 +342,7 @@ If you have downloaded extra fonts you can mount the folder to the path
 path during initialisation.
 
 ```
-ie VERSION=2.20.0
+ie VERSION=2.20.2
 docker run -v fonts:/opt/fonts -p 8080:8080 -t kartoza/geoserver:${VERSION} 
 ```
 


### PR DESCRIPTION
Update to 2.20.2 for http://geoserver.org/announcements/2021/12/13/logj4-rce-statement.html patches regarding  CVE-2021-44228 and CVE-2019-17571