### PR TITLE
Allow redirection to GeoServer webapp when TOMCAT_EXTRAS=false

### DIFF
--- a/.env
+++ b/.env
@@ -24,6 +24,8 @@ FOOTPRINTS_DATA_DIR=/opt/footprints_dir
 GEOWEBCACHE_CACHE_DIR=/opt/geoserver/data_dir/gwc
 # Show the tomcat manager in the browser
 TOMCAT_EXTRAS=true
+# Redirect to GeoServer web interface
+ROOT_WEBAPP_REDIRECT=false
 # https://docs.geoserver.org/stable/en/user/production/container.html#optimize-your-jvm
 INITIAL_MEMORY=2G
 # https://docs.geoserver.org/stable/en/user/production/container.html#optimize-your-jvm
@@ -42,8 +44,8 @@ LOGIN_STATUS=on
 # https://docs.geoserver.org/latest/en/user/production/config.html#disable-the-geoserver-web-administration-interface
 DISABLE_WEB_INTERFACE=false
 # Rendering settings
-ENABLE_JSONP=true 
-MAX_FILTER_RULES=20 
+ENABLE_JSONP=true
+MAX_FILTER_RULES=20
 OPTIMIZE_LINE_WIDTH=false
 # Install the stable plugin specified in https://github.com/kartoza/docker-geoserver/blob/master/build_data/stable_plugins.txt
 STABLE_EXTENSIONS=
@@ -51,35 +53,35 @@ STABLE_EXTENSIONS=
 COMMUNITY_EXTENSIONS=
 # SSL Settings explained here https://github.com/AtomGraph/letsencrypt-tomcat
 SSL=false
-HTTP_PORT=8080 
-HTTP_PROXY_NAME= 
-HTTP_PROXY_PORT= 
-HTTP_REDIRECT_PORT= 
-HTTP_CONNECTION_TIMEOUT=20000 
-HTTPS_PORT=8443 
-HTTPS_MAX_THREADS=150 
-HTTPS_CLIENT_AUTH= 
-HTTPS_PROXY_NAME= 
-HTTPS_PROXY_PORT= 
-JKS_FILE=letsencrypt.jks 
-JKS_KEY_PASSWORD='geoserver' 
-KEY_ALIAS=letsencrypt 
-JKS_STORE_PASSWORD='geoserver' 
-P12_FILE=letsencrypt.p12 
-PKCS12_PASSWORD='geoserver' 
+HTTP_PORT=8080
+HTTP_PROXY_NAME=
+HTTP_PROXY_PORT=
+HTTP_REDIRECT_PORT=
+HTTP_CONNECTION_TIMEOUT=20000
+HTTPS_PORT=8443
+HTTPS_MAX_THREADS=150
+HTTPS_CLIENT_AUTH=
+HTTPS_PROXY_NAME=
+HTTPS_PROXY_PORT=
+JKS_FILE=letsencrypt.jks
+JKS_KEY_PASSWORD='geoserver'
+KEY_ALIAS=letsencrypt
+JKS_STORE_PASSWORD='geoserver'
+P12_FILE=letsencrypt.p12
+PKCS12_PASSWORD='geoserver'
 LETSENCRYPT_CERT_DIR=/etc/letsencrypt
-CHARACTER_ENCODING='UTF-8' 
+CHARACTER_ENCODING='UTF-8'
 # Clustering  variables
 # Activates clustering using JMS cluster plugin
 CLUSTERING=False
 # cluster env variables specified https://docs.geoserver.org/stable/en/user/community/jms-cluster/index.html
-CLUSTER_DURABILITY=true 
-BROKER_URL= 
-READONLY=disabled 
-RANDOMSTRING=23bd87cfa327d47e 
-INSTANCE_STRING=ac3bcba2fa7d989678a01ef4facc4173010cd8b40d2e5f5a8d18d5f863ca976f 
-TOGGLE_MASTER=true 
-TOGGLE_SLAVE=true 
+CLUSTER_DURABILITY=true
+BROKER_URL=
+READONLY=disabled
+RANDOMSTRING=23bd87cfa327d47e
+INSTANCE_STRING=ac3bcba2fa7d989678a01ef4facc4173010cd8b40d2e5f5a8d18d5f863ca976f
+TOGGLE_MASTER=true
+TOGGLE_SLAVE=true
 EMBEDDED_BROKER=enabled
 # kartoza/postgis env variables https://github.com/kartoza/docker-postgis
 POSTGIS_VERSION_TAG=14-3.1

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ ie VERSION=2.20.0
 docker run -it --name geoserver  -e TOMCAT_EXTRAS=true -p 8600:8080 kartoza/geoserver:${VERSION} 
 ```
 
+**Note:** If `TOMCAT_EXTRAS` is set to false, requests to the root webapp ("/") will return HTTP status code 404. To issue a redirect to the GeoServer webapp ("/geoserver/web") set `ROOT_WEBAPP_REDIRECT=true`
+
 ### Upgrading image to use a specific version
 During initialization, the image will run a script that updates the passwords. This 
 is recommended to change passwords the first time that GeoServer runs. If you are migrating

--- a/build_data/index.jsp
+++ b/build_data/index.jsp
@@ -1,0 +1,5 @@
+<%
+  final String redirectURL = "/geoserver/web/";
+  response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+  response.setHeader("Location", redirectURL);
+%>

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -26,6 +26,10 @@ if [ -z "${TOMCAT_EXTRAS}" ]; then
   TOMCAT_EXTRAS=true
 fi
 
+if [ -z "${ROOT_WEBAPP_REDIRECT}" ]; then
+  ROOT_WEBAPP_REDIRECT=false
+fi
+
 if [ -z "${HTTP_PORT}" ]; then
   HTTP_PORT=8080
 fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -199,6 +199,11 @@ else
     delete_folder "${CATALINA_HOME}"/webapps/examples &&
     delete_folder "${CATALINA_HOME}"/webapps/host-manager &&
     delete_folder "${CATALINA_HOME}"/webapps/manager
+
+    if [[ "${ROOT_WEBAPP_REDIRECT}" =~ [Tt][Rr][Uu][Ee] ]]; then
+        mkdir "${CATALINA_HOME}"/webapps/ROOT
+        cp /build_data/index.jsp "${CATALINA_HOME}"/webapps/ROOT/index.jsp
+    fi
 fi
 
 


### PR DESCRIPTION
Include a new environment variable `ROOT_WEBAPP_REDIRECT` to issue a redirect from the root webapp ("/") to geoserver webapp ("/geoserver/web").

This only applies when `TOMCAT_EXTRAS=false`

Fixes #319 