### PR TITLE
re-add wps-plugin in stable plugins

### DIFF
--- a/build_data/stable_plugins.txt
+++ b/build_data/stable_plugins.txt
@@ -32,6 +32,7 @@ teradata-plugin
 wcs2_0-eo-plugin
 web-resource-plugin
 wmts-multi-dimensional-plugin
+wps-plugin
 wps-cluster-hazelcast-plugin
 wps-download-plugin
 wps-jdbc-plugin


### PR DESCRIPTION
It seems the wps-plugin has been removed with https://github.com/kartoza/docker-geoserver/pull/358 and replaced by wps-download-plugin, although it's a different plugin. See it listed in the Services extensions at http://geoserver.org/release/stable/