### PR TITLE
Fix item indent in YAML files

### DIFF
--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -8,7 +8,7 @@ services:
    db:
       image: kartoza/postgis:${POSTGIS_VERSION_TAG}
       volumes:
-         - geo-db-data:/var/lib/postgresql
+        - geo-db-data:/var/lib/postgresql
       ports:
         - ${POSTGRES_PORT}:5432
       environment:
@@ -55,4 +55,3 @@ services:
        - geoserver
      ports:
        - "80:80"
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
    db:
       image: kartoza/postgis:${POSTGIS_VERSION_TAG}
       volumes:
-         - geo-db-data:/var/lib/postgresql
+        - geo-db-data:/var/lib/postgresql
       ports:
         - ${POSTGRES_PORT}:5432
       environment:


### PR DESCRIPTION
This fixes a minor indent issue which confused me for a while, as it was causing a YAML parsing error when I tried adding a new `volumes` item without realizing that it wasn't at the same indent level.