### PR TITLE
Upgraded GeoServer from version 2.20.2 to 2.20.3

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,11 @@
 COMPOSE_PROJECT_NAME=kartozageoserver
 
 IMAGE_VERSION=9.0-jdk11-openjdk-slim-buster
-GS_VERSION=2.20.2
+GS_VERSION=2.20.3
 GEOSERVER_PORT=8600
 # Build Arguments
 JAVA_HOME=/usr/local/openjdk-11
-WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/2.20.2/geoserver-2.20.2-war.zip
+WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/2.20.3/geoserver-2.20.3-war.zip
 STABLE_PLUGIN_BASE_URL=https://liquidtelecom.dl.sourceforge.net
 DOWNLOAD_ALL_STABLE_EXTENSIONS=1
 DOWNLOAD_ALL_COMMUNITY_EXTENSIONS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG JAVA_HOME=/usr/local/openjdk-11
 FROM tomcat:$IMAGE_VERSION
 
 LABEL maintainer="Tim Sutton<tim@linfiniti.com>"
-ARG GS_VERSION=2.20.2
+ARG GS_VERSION=2.20.3
 ARG WAR_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
 ARG STABLE_PLUGIN_BASE_URL=https://liquidtelecom.dl.sourceforge.net
 ARG DOWNLOAD_ALL_STABLE_EXTENSIONS=1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The preferred way (but using most bandwidth for the initial image) is to
 get our docker trusted build like this:
 
 ```shell
-VERSION=2.20.2
+VERSION=2.20.3
 docker pull kartoza/geoserver:$VERSION
 ```
 ### Building the image
@@ -95,13 +95,13 @@ To build using a specific tagged release for tomcat image set the
 to choose which tag you need to build against.
 
 ```
-ie VERSION=2.20.2
-docker build --build-arg IMAGE_VERSION=8-jre8 --build-arg GS_VERSION=2.20.2 -t kartoza/geoserver:${VERSION} .
+ie VERSION=2.20.3
+docker build --build-arg IMAGE_VERSION=8-jre8 --build-arg GS_VERSION=2.20.3 -t kartoza/geoserver:${VERSION} .
 ```
 
 For some recent builds it is necessary to set the JAVA_PATH as well (e.g. Apache Tomcat/9.0.36)
 ```
-docker build --build-arg IMAGE_VERSION=9-jdk11-openjdk-slim --build-arg JAVA_HOME=/usr/local/openjdk-11/bin/java --build-arg GS_VERSION=2.20.2 -t kartoza/geoserver:2.20.2 .
+docker build --build-arg IMAGE_VERSION=9-jdk11-openjdk-slim --build-arg JAVA_HOME=/usr/local/openjdk-11/bin/java --build-arg GS_VERSION=2.20.3 -t kartoza/geoserver:2.20.3 .
 ```
 
 **Note:** Please check the [GeoServer documentation](https://docs.geoserver.org/stable/en/user/production/index.html) to see which tomcat versions 
@@ -125,7 +125,7 @@ The image ships with the following stable plugins:
 * csw-plugin
 
 **Note:** The plugins listed above are omitted from [Stable_plugins.txt](https://github.com/kartoza/docker-geoserver/blob/master/build_data/stable_plugins.txt)
-even though they are considered [stable plugins](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.2/extensions/)
+even though they are considered [stable plugins](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.3/extensions/)
 The image activates them on startup.
 
 The image provides the necessary plugin zip files which are used when activating the
@@ -143,7 +143,7 @@ The environment variable `STABLE_EXTENSIONS` can be used to activate plugins lis
 Example
 
 ```
-ie VERSION=2.20.2
+ie VERSION=2.20.3
 docker run -d -p 8600:8080 --name geoserver -e STABLE_EXTENSIONS=charts-plugin,db2-plugin kartoza/geoserver:${VERSION} 
 
 ```
@@ -164,7 +164,7 @@ The environment variable `COMMUNITY_EXTENSIONS` can be used to activate plugins 
 Example 
 
 ``` 
-ie VERSION=2.20.2
+ie VERSION=2.20.3
 docker run -d -p 8600:8080 --name geoserver -e COMMUNITY_EXTENSIONS=gwc-sqlite-plugin,ogr-datastore-plugin kartoza/geoserver:${VERSION} 
 
 ```
@@ -179,7 +179,7 @@ Geoserver ships with sample data which can be used by users to familiarize them 
 This is not activated by default. You can activate it using the environment variable `SAMPLE_DATA=true` 
 
 ``` 
-ie VERSION=2.20.2
+ie VERSION=2.20.3
 docker run -d -p 8600:8080 --name geoserver -e SAMPLE_DATA=true kartoza/geoserver:${VERSION} 
 
 ```
@@ -254,14 +254,14 @@ If you set the environment variable `SSL=true` but do not provide the pem files 
 the container will generate a self-signed SSL certificates.
 
 ```
-ie VERSION=2.20.2
+ie VERSION=2.20.3
 docker run -it --name geoserver  -e PKCS12_PASSWORD=geoserver -e JKS_KEY_PASSWORD=geoserver -e JKS_STORE_PASSWORD=geoserver -e SSL=true -p 8443:8443 -p 8600:8080 kartoza/geoserver:${VERSION} 
 ```
 
 If you already have your perm files (fullchain.pem and privkey.pem) you can mount the directory containing your keys as:
 
 ``` 
-ie VERSION=2.20.2
+ie VERSION=2.20.3
 docker run -it --name geo -v /etc/certs:/etc/certs  -e PKCS12_PASSWORD=geoserver -e JKS_KEY_PASSWORD=geoserver -e JKS_STORE_PASSWORD=geoserver -e SSL=true -p 8443:8443 -p 8600:8080 kartoza/geoserver:${VERSION}  
 
 ```
@@ -323,7 +323,7 @@ To include Tomcat extras including docs, examples, and the manager webapp, set t
 to use a strong password otherwise the default one is set up.
 
 ```
-ie VERSION=2.20.2
+ie VERSION=2.20.3
 docker run -it --name geoserver  -e TOMCAT_EXTRAS=true -p 8600:8080 kartoza/geoserver:${VERSION} 
 ```
 
@@ -345,7 +345,7 @@ If you have downloaded extra fonts you can mount the folder to the path
 path during initialisation.
 
 ```
-ie VERSION=2.20.2
+ie VERSION=2.20.3
 docker run -v fonts:/opt/fonts -p 8080:8080 -t kartoza/geoserver:${VERSION} 
 ```
 


### PR DESCRIPTION
Just noticed the convenient `upgrade_geoserver_version.sh` script after I already made the changes :)

Would it be possible to trigger a Docker release after this is successfully merged?