### PR TITLE
missing USE_DATETIME_IN_SHAPEFILE default value

### DIFF
--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -302,4 +302,7 @@ if [ -z ${HASHING_ALGORITHM} ];then
     HASHING_ALGORITHM='SHA-256'
 fi
 
+if [ -z "${USE_DATETIME_IN_SHAPEFILE}" ]; then
+    USE_DATETIME_IN_SHAPEFILE=true
+fi
 


### PR DESCRIPTION
During last merge with conflict resolution, USE_DATETIME_IN_SHAPEFILE default value was removed. Bringing back.