### PR TITLE
adding database schema to disk quota store postgres backend, it works…

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,22 @@ Some additional environment variables to use when activating the disk quota are:
 If you are using the `kartoza/docker-postgis` image as a database backend you can additionally
 configure communication between the containers to use [SSL](https://github.com/kartoza/docker-postgis#postgres-ssl-setup)
 
+If you want to test it locally with docker-compose postgres db you need to specify these env variables:
+
+        - DB_BACKEND=POSTGRES               
+        - HOST=db                          
+        - POSTGRES_PORT=5432                
+        - POSTGRES_DB=gwc                   
+        - POSTGRES_USER=${POSTGRES_USER}    
+        - POSTGRES_PASS=${POSTGRES_PASS}    
+        - SSL_MODE=allow                    
+        - POSTGRES_SCHEMA=public           
+        - DISK_QUOTA_SIZE=5                 
+
+NOTE: 
+
+    HOST should be your local container name for db
+    POSTGRES_SCHEMA works only with 'public' right now
 #### Using SSL and Default PostgreSQL ssl certificates
 
 When the environment variable `FORCE_SSL=TRUE` is set for the database container you

--- a/build_data/geowebcache-diskquota-jdbc.xml
+++ b/build_data/geowebcache-diskquota-jdbc.xml
@@ -2,7 +2,7 @@
   <dialect>PostgreSQL</dialect>
   <connectionPool>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://${HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?${SSL_PARAMETERS}</url>
+    <url>jdbc:postgresql://${HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?${SSL_PARAMETERS}&currentSchema=${POSTGRES_SCHEMA}</url>
     <username>${POSTGRES_USER}</username>
     <password>${POSTGRES_PASS}</password>
     <minConnections>1</minConnections>

--- a/build_data/geowebcache-diskquota-jdbc.xml
+++ b/build_data/geowebcache-diskquota-jdbc.xml
@@ -2,7 +2,7 @@
   <dialect>PostgreSQL</dialect>
   <connectionPool>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://${HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?${SSL_PARAMETERS}&currentSchema=${POSTGRES_SCHEMA}</url>
+    <url>jdbc:postgresql://${HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?${SSL_PARAMETERS}&amp;currentSchema=${POSTGRES_SCHEMA}</url>
     <username>${POSTGRES_USER}</username>
     <password>${POSTGRES_PASS}</password>
     <minConnections>1</minConnections>

--- a/build_data/geowebcache-diskquota.xml
+++ b/build_data/geowebcache-diskquota.xml
@@ -1,6 +1,6 @@
 <gwcQuotaConfiguration>
   <enabled>true</enabled>
-  <cacheCleanUpFrequency>5</cacheCleanUpFrequency>
+  <cacheCleanUpFrequency>${DISK_QUOTA_FREQUENCY}</cacheCleanUpFrequency>
   <cacheCleanUpUnits>SECONDS</cacheCleanUpUnits>
   <maxConcurrentCleanUps>2</maxConcurrentCleanUps>
   <globalExpirationPolicyName>LFU</globalExpirationPolicyName>

--- a/build_data/gwc-gs.xml
+++ b/build_data/gwc-gs.xml
@@ -1,0 +1,43 @@
+<GeoServerGWCConfig>
+  <version>1.1.0</version>
+  <directWMSIntegrationEnabled>${WMS_DIR_INTEGRATION}</directWMSIntegrationEnabled>
+  <requireTiledParameter>true</requireTiledParameter>
+  <WMSCEnabled>true</WMSCEnabled>
+  <TMSEnabled>true</TMSEnabled>
+  <securityEnabled>false</securityEnabled>
+  <innerCachingEnabled>false</innerCachingEnabled>
+  <persistenceEnabled>true</persistenceEnabled>
+  <cacheProviderClass>class org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider</cacheProviderClass>
+  <cacheConfigurations>
+    <entry>
+      <string>class org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider</string>
+      <InnerCacheConfiguration>
+        <hardMemoryLimit>16</hardMemoryLimit>
+        <policy>NULL</policy>
+        <concurrencyLevel>4</concurrencyLevel>
+        <evictionTime>120</evictionTime>
+      </InnerCacheConfiguration>
+    </entry>
+  </cacheConfigurations>
+  <cacheLayersByDefault>true</cacheLayersByDefault>
+  <cacheNonDefaultStyles>true</cacheNonDefaultStyles>
+  <metaTilingX>4</metaTilingX>
+  <metaTilingY>4</metaTilingY>
+  <gutter>0</gutter>
+  <defaultCachingGridSetIds>
+    <string>EPSG:4326</string>
+    <string>EPSG:900913</string>
+  </defaultCachingGridSetIds>
+  <defaultCoverageCacheFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultCoverageCacheFormats>
+  <defaultVectorCacheFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultVectorCacheFormats>
+  <defaultOtherCacheFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultOtherCacheFormats>
+</GeoServerGWCConfig>

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -87,13 +87,6 @@ chown -R "${USER_NAME}":"${GEO_GROUP_NAME}" "${CATALINA_HOME}" "${FOOTPRINTS_DAT
 "${GEOSERVER_HOME}" "${EXTRA_CONFIG_DIR}"  /usr/share/fonts/ /scripts /tomcat_apps.zip \
 /tmp/ "${GEOWEBCACHE_CACHE_DIR}";chmod o+rw "${CERT_DIR}";chmod 400 ${CATALINA_HOME}/conf/*
 
-echo -e "[Entrypoint] Checking PostgreSQL connection to see if init tables are loaded: \033[0m"
-if [[  "$DB_BACKEND" =~ [Pp][Oo][Ss][Tt][Gg][Rr][Ee][Ss] ]];then
-  export PGPASSWORD="${POSTGRES_PASS}"
-  postgres_ready_status ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB
-  create_gwc_tile_tables ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB $POSTGRES_SCHEMA
-fi
-
 if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
   exec gosu ${USER_NAME} ${GEOSERVER_HOME}/bin/startup.sh
 else

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -91,6 +91,7 @@ echo -e "[Entrypoint] Checking PostgreSQL connection to see if init tables are l
 if [[  "$DB_BACKEND" =~ [Pp][Oo][Ss][Tt][Gg][Rr][Ee][Ss] ]];then
   export PGPASSWORD="${POSTGRES_PASS}"
   postgres_ready_status ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB
+  create_gwc_tile_tables ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB $POSTGRES_SCHEMA
 fi
 
 if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -18,6 +18,10 @@ if [ -z "${DISK_QUOTA_SIZE}" ]; then
   DISK_QUOTA_SIZE=20
 fi
 
+if [ -z "${POSTGRES_SCHEMA}"]; then
+    POSTGRES_SCHEMA=public
+fi
+
 if [ -z "${SSL}" ]; then
   SSL=false
 fi

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -19,7 +19,7 @@ if [ -z "${DISK_QUOTA_SIZE}" ]; then
 fi
 
 if [ -z "${POSTGRES_SCHEMA}"]; then
-    POSTGRES_SCHEMA=public
+    POSTGRES_SCHEMA='public'
 fi
 
 if [ -z "${SSL}" ]; then

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -18,8 +18,12 @@ if [ -z "${DISK_QUOTA_SIZE}" ]; then
   DISK_QUOTA_SIZE=20
 fi
 
-if [ -z "${POSTGRES_SCHEMA}"]; then
-    POSTGRES_SCHEMA='public'
+if [ -z "${DISK_QUOTA_FREQUENCY}" ]; then
+  DISK_QUOTA_FREQUENCY=5
+fi
+
+if [ -z "${POSTGRES_SCHEMA}" ]; then
+    POSTGRES_SCHEMA=public
 fi
 
 if [ -z "${SSL}" ]; then
@@ -185,6 +189,10 @@ fi
 
 if [ -z "${RECREATE_DATADIR}" ]; then
     RECREATE_DATADIR=false
+fi
+
+if [ -z "${RECREATE_DISKQUOTA}" ]; then
+    RECREATE_DISKQUOTA=false
 fi
 
 if [ -z "${RESET_ADMIN_CREDENTIALS}" ]; then

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -14,6 +14,10 @@ if [ -z "${OPTIMIZE_LINE_WIDTH}" ]; then
   OPTIMIZE_LINE_WIDTH=false
 fi
 
+if [ -z "${WMS_DIR_INTEGRATION}" ]; then
+  WMS_DIR_INTEGRATION=false
+fi
+
 if [ -z "${DISK_QUOTA_SIZE}" ]; then
   DISK_QUOTA_SIZE=20
 fi

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -409,3 +409,18 @@ function postgres_ready_status() {
   sleep 1
 done
 }
+
+function create_gwc_tile_tables(){
+  HOST="$1"
+  PORT="$2"
+  USER="$3"
+  DB="$4"
+  POSTGRES_SCHEMA="$5"
+  if [ ${POSTGRES_SCHEMA} != 'public' ]; then
+   psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE SCHEMA IF NOT EXISTS ${POSTGRES_SCHEMA}"
+   psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE TABLE IF NOT EXISTS ${POSTGRES_SCHEMA}.tileset(key character varying(320) COLLATE pg_catalog.\"default\" NOT NULL,layer_name character varying(128) COLLATE pg_catalog.\"default\",gridset_id character varying(32) COLLATE pg_catalog.\"default\",blob_format character varying(64) COLLATE pg_catalog.\"default\",parameters_id character varying(41) COLLATE pg_catalog.\"default\",bytes numeric(21,0) NOT NULL DEFAULT 0,CONSTRAINT tileset_pkey PRIMARY KEY (key))"
+   psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE TABLE IF NOT EXISTS $POSTGRES_SCHEMA.tilepage(key character varying(320) COLLATE pg_catalog.\"default\" NOT NULL,tileset_id character varying(320) COLLATE pg_catalog."default",page_z smallint,page_x integer,page_y integer,creation_time_minutes integer,frequency_of_use double precision,last_access_time_minutes integer,fill_factor double precision,num_hits numeric(64,0),CONSTRAINT tilepage_pkey PRIMARY KEY (key),CONSTRAINT tilepage_tileset_id_fkey FOREIGN KEY (tileset_id) REFERENCES $POSTGRES_SCHEMA.tileset (key) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE CASCADE)"
+  fi
+
+}
+

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -131,8 +131,6 @@ function validate_geo_install() {
 
 }
 
-
-
 function unzip_geoserver() {
   if [[ -f /tmp/geoserver/geoserver.war ]]; then
     unzip /tmp/geoserver/geoserver.war -d "${CATALINA_HOME}"/webapps/geoserver &&
@@ -150,8 +148,6 @@ else
 fi
 
 }
-
-
 
 # A little logic that will fetch the geoserver war zip file if it is not available locally in the resources dir
 function package_geoserver() {
@@ -278,9 +274,9 @@ function default_disk_quota_config() {
 
 function jdbc_disk_quota_config() {
 
-  if [[ ! -f ${GEOWEBCACHE_CACHE_DIR}/geowebcache-diskquota-jdbc.xml ]]; then
+  if [[ ! -f "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml ]]; then
     # If it doesn't exists, copy from /settings directory if exists
-    if [[ -f ${EXTRA_CONFIG_DIR}/geowebcache-diskquota-jdbc.xml ]]; then
+    if [[ -f "${EXTRA_CONFIG_DIR}"/geowebcache-diskquota-jdbc.xml ]]; then
       envsubst < "${EXTRA_CONFIG_DIR}"/geowebcache-diskquota-jdbc.xml < "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml
     else
       # default value
@@ -418,8 +414,8 @@ function create_gwc_tile_tables(){
   POSTGRES_SCHEMA="$5"
   if [ ${POSTGRES_SCHEMA} != 'public' ]; then
    psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE SCHEMA IF NOT EXISTS ${POSTGRES_SCHEMA}"
-   psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE TABLE IF NOT EXISTS ${POSTGRES_SCHEMA}.tileset(key character varying(320) COLLATE pg_catalog.\"default\" NOT NULL,layer_name character varying(128) COLLATE pg_catalog.\"default\",gridset_id character varying(32) COLLATE pg_catalog.\"default\",blob_format character varying(64) COLLATE pg_catalog.\"default\",parameters_id character varying(41) COLLATE pg_catalog.\"default\",bytes numeric(21,0) NOT NULL DEFAULT 0,CONSTRAINT tileset_pkey PRIMARY KEY (key))"
-   psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE TABLE IF NOT EXISTS $POSTGRES_SCHEMA.tilepage(key character varying(320) COLLATE pg_catalog.\"default\" NOT NULL,tileset_id character varying(320) COLLATE pg_catalog."default",page_z smallint,page_x integer,page_y integer,creation_time_minutes integer,frequency_of_use double precision,last_access_time_minutes integer,fill_factor double precision,num_hits numeric(64,0),CONSTRAINT tilepage_pkey PRIMARY KEY (key),CONSTRAINT tilepage_tileset_id_fkey FOREIGN KEY (tileset_id) REFERENCES $POSTGRES_SCHEMA.tileset (key) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE CASCADE)"
+   psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE TABLE IF NOT EXISTS ${POSTGRES_SCHEMA}.tileset(key character varying(320) NOT NULL,layer_name character varying(128),gridset_id character varying(32) ,blob_format character varying(64) ,parameters_id character varying(41) ,bytes numeric(21,0) NOT NULL DEFAULT 0,CONSTRAINT tileset_pkey PRIMARY KEY (key))"
+   psql -d "$DB" -p "$PORT" -U "$USER" -h "$HOST" -c "CREATE TABLE IF NOT EXISTS $POSTGRES_SCHEMA.tilepage(key character varying(320) NOT NULL,tileset_id character varying(320),page_z smallint,page_x integer,page_y integer,creation_time_minutes integer,frequency_of_use double precision,last_access_time_minutes integer,fill_factor double precision,num_hits numeric(64,0),CONSTRAINT tilepage_pkey PRIMARY KEY (key),CONSTRAINT tilepage_tileset_id_fkey FOREIGN KEY (tileset_id) REFERENCES $POSTGRES_SCHEMA.tileset (key) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE CASCADE)"
   fi
 
 }

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -285,6 +285,20 @@ function jdbc_disk_quota_config() {
   fi
 }
 
+function enable_direct_integration_wms() {
+  if [[ ! -f "${GEOSERVER_DATA_DIR}"/gwc-gs.xml ]]; then
+    if [[ -f "${EXTRA_CONFIG_DIR}"/gwc-gs.xml ]]; then
+      envsubst < "${EXTRA_CONFIG_DIR}"/gwc-gs.xml < "${GEOSERVER_DATA_DIR}"/gwc-gs.xml
+    else
+      # default value
+      envsubst < /build_data/gwc-gs.xml > "${GEOSERVER_DATA_DIR}"/gwc-gs.xml
+    fi
+  else
+      # default value
+      envsubst < /build_data/gwc-gs.xml > "${GEOSERVER_DATA_DIR}"/gwc-gs.xml
+  fi
+}
+
 # Function to setup control flow https://docs.geoserver.org/stable/en/user/extensions/controlflow/index.html
 function setup_control_flow() {
   if [[ ! -f "${GEOSERVER_DATA_DIR}"/controlflow.properties ]]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -69,7 +69,9 @@ else
   default_disk_quota_config
 fi
 
-
+# Direct Integration with GeoServer WMS
+echo "Direct Integration with Geoserver WMS option"
+enable_direct_integration_wms
 
 # Install stable plugins
 if [[ -z "${STABLE_EXTENSIONS}" ]]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -38,6 +38,19 @@ if [[ ${SAMPLE_DATA} =~ [Tt][Rr][Uu][Ee] ]]; then
 fi
 
 
+# Recreate DISK QUOTA config, useful to change between H2 and jdbc and change connection or schema
+if [[ "${RECREATE_DISKQUOTA}" =~ [Tt][Rr][Uu][Ee] ]]; then
+
+  echo "Remove old geowebcache disk quota xml."
+  if [[ -f "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota.xml ]]; then
+    rm "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota.xml
+    echo "${GEOWEBCACHE_CACHE_DIR}/geowebcache-diskquota.xml removed"
+  fi
+  if [[ -f "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml ]]; then
+    rm "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml
+    echo "${GEOWEBCACHE_CACHE_DIR}/geowebcache-diskquota-jdbc.xml removed"
+  fi
+fi
 
 export DISK_QUOTA_SIZE
 if [[  ${DB_BACKEND} =~ [Pp][Oo][Ss][Tt][Gg][Rr][Ee][Ss] ]]; then
@@ -46,10 +59,14 @@ if [[  ${DB_BACKEND} =~ [Pp][Oo][Ss][Tt][Gg][Rr][Ee][Ss] ]]; then
   export SSL_PARAMETERS=${PARAMS}
   default_disk_quota_config
   jdbc_disk_quota_config
+
+  echo -e "[Entrypoint] Checking PostgreSQL connection to see if init tables are loaded: \033[0m"
+  export PGPASSWORD="${POSTGRES_PASS}"
+  postgres_ready_status ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB
+  create_gwc_tile_tables ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB $POSTGRES_SCHEMA
 else
   export DISK_QUOTA_BACKEND=H2
   default_disk_quota_config
-
 fi
 
 


### PR DESCRIPTION
adding database schema to disk quota store postgres backend, it works only with public right now, can be used later when geoserver will fix this because by default it creates the two needed tables only in default public schema