### PR TITLE
Upgraded GeoServer from version 2.22.0 to 2.22.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,11 @@
 COMPOSE_PROJECT_NAME=kartozageoserver
 
 IMAGE_VERSION=9.0.71-jdk11-temurin-focal
-GS_VERSION=2.22.0
+GS_VERSION=2.22.1
 GEOSERVER_PORT=8600
 # Build Arguments
 JAVA_HOME=/usr/local/openjdk-11
-WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/2.22.0/geoserver-2.22.0-war.zip
+WAR_URL=http://downloads.sourceforge.net/project/geoserver/GeoServer/2.22.1/geoserver-2.22.1-war.zip
 STABLE_PLUGIN_BASE_URL=https://sourceforge.net/projects/geoserver/files/GeoServer
 DOWNLOAD_ALL_STABLE_EXTENSIONS=1
 DOWNLOAD_ALL_COMMUNITY_EXTENSIONS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG JAVA_HOME=/usr/local/openjdk-11
 FROM tomcat:$IMAGE_VERSION
 
 LABEL maintainer="Tim Sutton<tim@linfiniti.com>"
-ARG GS_VERSION=2.22.0
+ARG GS_VERSION=2.22.1
 ARG WAR_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
 ARG STABLE_PLUGIN_BASE_URL=https://sourceforge.net/projects/geoserver/files/GeoServer
 ARG DOWNLOAD_ALL_STABLE_EXTENSIONS=1

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The preferred way (but using most bandwidth for the initial image) is to
 get our docker trusted build like this:
 
 ```shell
-VERSION=2.22.0
+VERSION=2.22.1
 docker pull kartoza/geoserver:$VERSION
 ```
 ### Building the image
@@ -98,13 +98,13 @@ To build using a specific tagged release for tomcat image set the
 to choose which tag you need to build against.
 
 ```
-ie VERSION=2.22.0
-docker build --build-arg IMAGE_VERSION=8-jre8 --build-arg GS_VERSION=2.22.0 -t kartoza/geoserver:${VERSION} .
+ie VERSION=2.22.1
+docker build --build-arg IMAGE_VERSION=8-jre8 --build-arg GS_VERSION=2.22.1 -t kartoza/geoserver:${VERSION} .
 ```
 
 For some recent builds it is necessary to set the JAVA_PATH as well (e.g. Apache Tomcat/9.0.36)
 ```
-docker build --build-arg IMAGE_VERSION=9-jdk11-openjdk-slim --build-arg JAVA_HOME=/usr/local/openjdk-11/bin/java --build-arg GS_VERSION=2.22.0 -t kartoza/geoserver:2.22.0 .
+docker build --build-arg IMAGE_VERSION=9-jdk11-openjdk-slim --build-arg JAVA_HOME=/usr/local/openjdk-11/bin/java --build-arg GS_VERSION=2.22.1 -t kartoza/geoserver:2.22.1 .
 ```
 
 **Note:** Please check the [GeoServer documentation](https://docs.geoserver.org/stable/en/user/production/index.html) 
@@ -171,7 +171,7 @@ The image ships with the following stable plugins:
 * csw-plugin
 
 **Note:** The plugins listed above are omitted from [Stable_plugins.txt](https://github.com/kartoza/docker-geoserver/blob/master/build_data/stable_plugins.txt)
-even though they are considered [stable plugins](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.0/extensions/)
+even though they are considered [stable plugins](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.1/extensions/)
 The image activates them on startup.
 
 The image provides the necessary plugin zip files which are used when activating the
@@ -189,7 +189,7 @@ The environment variable `STABLE_EXTENSIONS` can be used to activate plugins lis
 Example
 
 ```
-ie VERSION=2.22.0
+ie VERSION=2.22.1
 docker run -d -p 8600:8080 --name geoserver -e STABLE_EXTENSIONS=charts-plugin,db2-plugin kartoza/geoserver:${VERSION}
 
 ```
@@ -210,7 +210,7 @@ The environment variable `COMMUNITY_EXTENSIONS` can be used to activate plugins 
 Example
 
 ```
-ie VERSION=2.22.0
+ie VERSION=2.22.1
 docker run -d -p 8600:8080 --name geoserver -e COMMUNITY_EXTENSIONS=gwc-sqlite-plugin,ogr-datastore-plugin kartoza/geoserver:${VERSION}
 
 ```
@@ -228,7 +228,7 @@ Geoserver ships with sample data which can be used by users to familiarize them 
 This is not activated by default. You can activate it using the environment variable `SAMPLE_DATA=true`
 
 ```
-ie VERSION=2.22.0
+ie VERSION=2.22.1
 docker run -d -p 8600:8080 --name geoserver -e SAMPLE_DATA=true kartoza/geoserver:${VERSION}
 
 ```
@@ -319,14 +319,14 @@ If you set the environment variable `SSL=true` but do not provide the pem files 
 the container will generate a self-signed SSL certificates.
 
 ```
-ie VERSION=2.22.0
+ie VERSION=2.22.1
 docker run -it --name geoserver  -e PKCS12_PASSWORD=geoserver -e JKS_KEY_PASSWORD=geoserver -e JKS_STORE_PASSWORD=geoserver -e SSL=true -p 8443:8443 -p 8600:8080 kartoza/geoserver:${VERSION}
 ```
 
 If you already have your perm files (fullchain.pem and privkey.pem) you can mount the directory containing your keys as:
 
 ```
-ie VERSION=2.22.0
+ie VERSION=2.22.1
 docker run -it --name geo -v /etc/certs:/etc/certs  -e PKCS12_PASSWORD=geoserver -e JKS_KEY_PASSWORD=geoserver -e JKS_STORE_PASSWORD=geoserver -e SSL=true -p 8443:8443 -p 8600:8080 kartoza/geoserver:${VERSION}
 
 ```
@@ -402,7 +402,7 @@ To include Tomcat extras including docs, examples, and the manager webapp, set t
 to use a strong password otherwise the default one is set up.
 
 ```
-ie VERSION=2.22.0
+ie VERSION=2.22.1
 docker run -it --name geoserver  -e TOMCAT_EXTRAS=true -p 8600:8080 kartoza/geoserver:${VERSION}
 ```
 
@@ -429,7 +429,7 @@ If you have downloaded extra fonts you can mount the folder to the path
 path during initialisation.
 
 ```
-ie VERSION=2.22.0
+ie VERSION=2.22.1
 docker run -v fonts:/opt/fonts -p 8080:8080 -t kartoza/geoserver:${VERSION}
 ```
 

--- a/clustering/docker-compose.yml
+++ b/clustering/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       healthcheck:
         test: "PGPASSWORD=docker pg_isready -h 127.0.0.1 -U docker -d gis"
    master:
-      image: kartoza/geoserver:2.22.0
+      image: kartoza/geoserver:2.22.1
       volumes:
          - geoserver-cluster-data:/opt/geoserver/data_dir
       ports:
@@ -50,7 +50,7 @@ services:
         timeout: 10s
         retries: 3
    node:
-      image: kartoza/geoserver:2.22.0
+      image: kartoza/geoserver:2.22.1
       volumes:
          - geoserver-cluster-data:/opt/geoserver/data_dir
       ports:

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -365,3 +365,6 @@ if [ -z "${RELINQUISH_LOG4J_CONTROL}" ]; then
   RELINQUISH_LOG4J_CONTROL=false
 fi
 
+if [ -z "${USE_DEFAULT_CREDENTIALS}" ]; then
+  USE_DEFAULT_CREDENTIALS=false
+fi

--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -15,90 +15,98 @@ else
   GEOSERVER_INSTALL_DIR=${CATALINA_HOME}
 fi
 
-SETUP_LOCKFILE="${EXTRA_CONFIG_DIR}/.first_time_hash.lock"
-if [[ ${RECREATE_DATADIR} =~ [Tt][Rr][Uu][Ee] ]];then
-    cp -r ${CATALINA_HOME}/security ${GEOSERVER_DATA_DIR}
-    delete_file ${SETUP_LOCKFILE} && \
-    delete_file "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt && \
-    delete_file "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt && \
-    delete_file "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt
+
+
+if [[ "${USE_DEFAULT_CREDENTIALS}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
+
+  SETUP_LOCKFILE="${EXTRA_CONFIG_DIR}/.first_time_hash.lock"
+  if [[ ${RECREATE_DATADIR} =~ [Tt][Rr][Uu][Ee] ]];then
+      cp -r ${CATALINA_HOME}/security ${GEOSERVER_DATA_DIR}
+      delete_file ${SETUP_LOCKFILE} && \
+      delete_file "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt && \
+      delete_file "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt && \
+      delete_file "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt
+  else
+      if [[ ! -f "${SETUP_LOCKFILE}"  ]]; then
+          if [ ! -d "${GEOSERVER_DATA_DIR}/security" ]; then
+            echo -e "\e[32m Copying default security folder \033[0m"
+            cp -r ${CATALINA_HOME}/security ${GEOSERVER_DATA_DIR}
+            sed -i 's/pbePasswordEncoder/strongPbePasswordEncoder/g' ${GEOSERVER_DATA_DIR}/security/config.xml
+          fi
+      fi
+  fi
+
+  # Set random password if none provided
+  if [[ -z ${GEOSERVER_ADMIN_PASSWORD} ]]; then
+        echo -e "\e[32m ------------------------------------------ \033[0m"
+        echo -e "\e[32m Set random password because none is provided \033[0m"
+        generate_random_string 15
+        GEOSERVER_ADMIN_PASSWORD=${RAND}
+        echo $GEOSERVER_ADMIN_PASSWORD >${GEOSERVER_DATA_DIR}/security/pass.txt
+        echo -e "[Entrypoint] GENERATED GeoServer  PASSWORD: \e[1;31m $GEOSERVER_ADMIN_PASSWORD \033[0m"
+  fi
+
+  USERS_XML=${USERS_XML:-${GEOSERVER_DATA_DIR}/security/usergroup/default/users.xml}
+  ROLES_XML=${ROLES_XML:-${GEOSERVER_DATA_DIR}/security/role/default/roles.xml}
+  CLASSPATH=${CLASSPATH:-${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib/}
+
+  # users.xml setup
+  cp $USERS_XML $USERS_XML.orig
+
+  # Get current GeoServer admin user
+  if [[ -f  "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt ]];then
+      GEOSERVER_ADMIN_DEFAULT_USER=$(cat "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt)
+  else
+      GEOSERVER_ADMIN_DEFAULT_USER=admin
+  fi
+
+  # Get encrypted admin password
+  if [[ -f "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt ]];then
+      export GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD=$(cat "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt)
+  else
+      export GEOSERVER_ADMIN_DEFAULT_PASSWORD=$(grep -o 'password=\".*\"' ${CATALINA_HOME}/security/usergroup/default/users.xml|awk -F':' '{print $2}')
+      export GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD="digest1:${GEOSERVER_ADMIN_DEFAULT_PASSWORD%?}"
+  fi
+
+
+  if [[ ! -f "${SETUP_LOCKFILE}"  ]]; then
+      echo -e "\e[32m ----------------------------------------------------- \033[0m"
+      echo -e "\e[32m  Run password encryption once for the first runtime \033[0m"
+      export PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD $CLASSPATH $HASHING_ALGORITHM)
+      cat $USERS_XML.orig | sed -e "s/ name=\"${GEOSERVER_ADMIN_DEFAULT_USER}\" / name=\"${GEOSERVER_ADMIN_USER}\" /" | sed -e "s/ password=\"${GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD//\//\\/}\"/ password=\"${PWD_HASH//\//\\/}\"/" > $USERS_XML
+      touch ${SETUP_LOCKFILE}
+  else
+
+      if [[ -f "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt ]];then
+          export GEOSERVER_ADMIN_PASSWORD_TEMP=$(cat "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt)
+
+          if [[ ${GEOSERVER_ADMIN_PASSWORD_TEMP} != ${GEOSERVER_ADMIN_PASSWORD} ]];then
+              echo -e "\e[32m --------------------------------------------------------- \033[0m"
+              echo -e "\e[32m  (Re)setting GEOSERVER_ADMIN_PASSWORD because it has changed \033[0m"
+              export PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD $CLASSPATH $HASHING_ALGORITHM)
+              cat $USERS_XML.orig | sed -e "s/ name=\"${GEOSERVER_ADMIN_DEFAULT_USER}\" / name=\"${GEOSERVER_ADMIN_USER}\" /" | sed -e "s/ password=\"${GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD//\//\\/}\"/ password=\"${PWD_HASH//\//\\/}\"/" > $USERS_XML
+          fi
+      fi
+  fi
+
+
+  # roles.xml setup
+  cp $ROLES_XML $ROLES_XML.orig
+  # <userRoles username="admin">
+  cat $ROLES_XML.orig | sed -e "s/ username=\"${GEOSERVER_ADMIN_DEFAULT_USER}\"/ username=\"${GEOSERVER_ADMIN_USER}\"/" > $ROLES_XML
+
+  # Set default passwords
+  echo "${GEOSERVER_ADMIN_USER}" > "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt
+  echo "${PWD_HASH}" > "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt
+  echo ${GEOSERVER_ADMIN_PASSWORD} > "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt
+
+  if [[ -f ${EXTRA_CONFIG_DIR}/users.xml ]]; then
+      cp ${EXTRA_CONFIG_DIR}/users.xml ${GEOSERVER_DATA_DIR}/security/usergroup/default/
+  fi
+  if [[ -f ${EXTRA_CONFIG_DIR}/roles.xml ]]; then
+      cp ${EXTRA_CONFIG_DIR}/roles.xml ${GEOSERVER_DATA_DIR}/security/role/default/roles.xml
+  fi
 else
-    if [[ ! -f "${SETUP_LOCKFILE}"  ]]; then
-        if [ ! -d "${GEOSERVER_DATA_DIR}/security" ]; then
-          echo -e "\e[32m Copying default security folder \033[0m"
-          cp -r ${CATALINA_HOME}/security ${GEOSERVER_DATA_DIR}
-          sed -i 's/pbePasswordEncoder/strongPbePasswordEncoder/g' ${GEOSERVER_DATA_DIR}/security/config.xml
-        fi
-    fi
-fi
+  cp -r ${CATALINA_HOME}/security ${GEOSERVER_DATA_DIR}
 
-# Set random password if none provided
-if [[ -z ${GEOSERVER_ADMIN_PASSWORD} ]]; then
-      echo -e "\e[32m ------------------------------------------ \033[0m"
-      echo -e "\e[32m Set random password because none is provided \033[0m"
-      generate_random_string 15
-      GEOSERVER_ADMIN_PASSWORD=${RAND}
-      echo $GEOSERVER_ADMIN_PASSWORD >${GEOSERVER_DATA_DIR}/security/pass.txt
-      echo -e "[Entrypoint] GENERATED GeoServer  PASSWORD: \e[1;31m $GEOSERVER_ADMIN_PASSWORD \033[0m"
-fi
-
-USERS_XML=${USERS_XML:-${GEOSERVER_DATA_DIR}/security/usergroup/default/users.xml}
-ROLES_XML=${ROLES_XML:-${GEOSERVER_DATA_DIR}/security/role/default/roles.xml}
-CLASSPATH=${CLASSPATH:-${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib/}
-
-# users.xml setup
-cp $USERS_XML $USERS_XML.orig
-
-# Get current GeoServer admin user
-if [[ -f  "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt ]];then
-    GEOSERVER_ADMIN_DEFAULT_USER=$(cat "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt)
-else
-    GEOSERVER_ADMIN_DEFAULT_USER=admin
-fi
-
-# Get encrypted admin password
-if [[ -f "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt ]];then
-    export GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD=$(cat "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt)
-else
-    export GEOSERVER_ADMIN_DEFAULT_PASSWORD=$(grep -o 'password=\".*\"' ${CATALINA_HOME}/security/usergroup/default/users.xml|awk -F':' '{print $2}')
-    export GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD="digest1:${GEOSERVER_ADMIN_DEFAULT_PASSWORD%?}"
-fi
-
-
-if [[ ! -f "${SETUP_LOCKFILE}"  ]]; then
-    echo -e "\e[32m ----------------------------------------------------- \033[0m"
-    echo -e "\e[32m  Run password encryption once for the first runtime \033[0m"
-    export PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD $CLASSPATH $HASHING_ALGORITHM)
-    cat $USERS_XML.orig | sed -e "s/ name=\"${GEOSERVER_ADMIN_DEFAULT_USER}\" / name=\"${GEOSERVER_ADMIN_USER}\" /" | sed -e "s/ password=\"${GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD//\//\\/}\"/ password=\"${PWD_HASH//\//\\/}\"/" > $USERS_XML
-    touch ${SETUP_LOCKFILE}
-else
-
-    if [[ -f "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt ]];then
-        export GEOSERVER_ADMIN_PASSWORD_TEMP=$(cat "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt)
-
-        if [[ ${GEOSERVER_ADMIN_PASSWORD_TEMP} != ${GEOSERVER_ADMIN_PASSWORD} ]];then
-            echo -e "\e[32m --------------------------------------------------------- \033[0m"
-            echo -e "\e[32m  (Re)setting GEOSERVER_ADMIN_PASSWORD because it has changed \033[0m"
-            export PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD $CLASSPATH $HASHING_ALGORITHM)
-            cat $USERS_XML.orig | sed -e "s/ name=\"${GEOSERVER_ADMIN_DEFAULT_USER}\" / name=\"${GEOSERVER_ADMIN_USER}\" /" | sed -e "s/ password=\"${GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD//\//\\/}\"/ password=\"${PWD_HASH//\//\\/}\"/" > $USERS_XML
-        fi
-    fi
-fi
-
-
-# roles.xml setup
-cp $ROLES_XML $ROLES_XML.orig
-# <userRoles username="admin">
-cat $ROLES_XML.orig | sed -e "s/ username=\"${GEOSERVER_ADMIN_DEFAULT_USER}\"/ username=\"${GEOSERVER_ADMIN_USER}\"/" > $ROLES_XML
-
-# Set default passwords
-echo "${GEOSERVER_ADMIN_USER}" > "${EXTRA_CONFIG_DIR}"/.default_admin_user.txt
-echo "${PWD_HASH}" > "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt
-echo ${GEOSERVER_ADMIN_PASSWORD} > "${EXTRA_CONFIG_DIR}"/.default_admin_pass.txt
-
-if [[ -f ${EXTRA_CONFIG_DIR}/users.xml ]]; then
-    cp ${EXTRA_CONFIG_DIR}/users.xml ${GEOSERVER_DATA_DIR}/security/usergroup/default/
-fi
-if [[ -f ${EXTRA_CONFIG_DIR}/roles.xml ]]; then
-    cp ${EXTRA_CONFIG_DIR}/roles.xml ${GEOSERVER_DATA_DIR}/security/role/default/roles.xml
 fi


### PR DESCRIPTION
Fixes #https://github.com/kartoza/docker-geoserver/issues/472 by adding a new env variable `USE_DEFAULT_CREDENTIALS`; that sets the username and password as `admin/geoserver` in case setting password doesn't work