### PR TITLE
Extract default admin password from DATA_DIR files rather than templates

### DIFF
--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -64,7 +64,7 @@ if [[ "${USE_DEFAULT_CREDENTIALS}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
   if [[ -f "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt ]];then
       export GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD=$(cat "${EXTRA_CONFIG_DIR}"/.default_admin_encrypted_pass.txt)
   else
-      export GEOSERVER_ADMIN_DEFAULT_PASSWORD=$(grep -o 'password=\".*\"' ${CATALINA_HOME}/security/usergroup/default/users.xml|awk -F':' '{print $2}')
+      export GEOSERVER_ADMIN_DEFAULT_PASSWORD=$(grep -o 'password=\".*\"' ${USERS_XML}|awk -F':' '{print $2}')
       export GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD="digest1:${GEOSERVER_ADMIN_DEFAULT_PASSWORD%?}"
   fi
 


### PR DESCRIPTION
When updating to a new GEOSERVER_ADMIN_PASSWORD value,  the `sed` statements at lines 71 and 82 of update_passwords.sh look for an exact match of GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD to replace with PWD_HASH.

If the geoserver container is launched with an empty /settings ($EXTRA_CONFIG_DIR) directory,  the value of GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD was being derived from the value in the Geoserver *templates* (`${CATALINA_HOME}/security/usergroup/default/users.xml`) and so the admin password will only be replaced if it previously had a non-encrypted value of `geoserver`.

This PR changes the logic slightly so that GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD is extracted from the users.xml file in the GEOSERVER_DATA_DIR, rather than from the users.xml file in the geoserver templates.   This means that you can just clear the mounted /settings/ directory to always override the admin password at launch, no matter what its previous value was.

This may assist with the login issues people have been reporting, e.g. #472. (which has been marked closed, but I was still seeing the same issue even with having mounted a /settings volume as per the latest docs)