### PR TITLE
Allow to change context-root

### DIFF
--- a/.env
+++ b/.env
@@ -29,6 +29,10 @@ GEOWEBCACHE_CACHE_DIR=/opt/geoserver/data_dir/gwc
 TOMCAT_EXTRAS=true
 # Redirect to GeoServer web interface
 ROOT_WEBAPP_REDIRECT=false
+# Deploy to another context-root than https://host/geoserver, ex: https://host/my-geoserver
+# GEOSERVER_CONTEXT_ROOT=my-geoserver
+# For runtime only, do not use at build-time.
+GEOSERVER_CONTEXT_ROOT=geoserver
 # https://docs.geoserver.org/stable/en/user/production/container.html#optimize-your-jvm
 INITIAL_MEMORY=2G
 # https://docs.geoserver.org/stable/en/user/production/container.html#optimize-your-jvm

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -1,0 +1,5 @@
+FROM pavics/geoserver:2.22.2-kartoza-build20230226
+
+ADD scripts /scripts
+
+RUN chmod +x /scripts/*.sh

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -1,5 +1,0 @@
-FROM pavics/geoserver:2.22.2-kartoza-build20230226
-
-ADD scripts /scripts
-
-RUN chmod +x /scripts/*.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
        * [Control flow properties](#control-flow-properties)
        * [Changing GeoServer password and username](#changing-geoserver-password-and-username)
            * [Docker secrets](#docker-secrets)
+       * [Changing GeoServer deployment context-root](#changing-geoserver-deployment-context-root)
    * [Mounting Configs](#mounting-configs)
        * [CORS Support](#cors-support)
    * [Clustering using JMS Plugin](#clustering-using-jms-plugin)
@@ -524,6 +525,20 @@ Currently, the following environment variables
  JKS_STORE_PASSWORD
 ```
 are supported.
+
+### Changing GeoServer deployment context-root
+
+You can pass the environment variable to change the context-root at runtime,
+example:
+```
+GEOSERVER_CONTEXT_ROOT=my-geoserver
+```
+
+The example above will deploy Geoserver at https://host/my-geoserver instead of
+the default location at https://host/geoserver.
+
+This variable is meant for runtime only.  At build-time, do not change this
+value so at runtime it can perform the proper context-root rename.
 
 
 ## Mounting Configs

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -29,6 +29,17 @@ mkdir -p  "${GEOSERVER_DATA_DIR}" "${CERT_DIR}" "${FOOTPRINTS_DATA_DIR}" "${FONT
 source /scripts/functions.sh
 source /scripts/env-data.sh
 
+# Rename to match wanted context-root and so that we can unzip plugins to
+# existing directory.
+if [ x"${GEOSERVER_CONTEXT_ROOT}" != xgeoserver ]; then
+  echo "INFO: changing context-root to '${GEOSERVER_CONTEXT_ROOT}'."
+  if [ -e "${CATALINA_HOME}/webapps/geoserver" ]; then
+    mv "${CATALINA_HOME}/webapps/geoserver" "${CATALINA_HOME}/webapps/${GEOSERVER_CONTEXT_ROOT}"
+  else
+    echo "WARN: '${CATALINA_HOME}/webapps/geoserver' not found, probably already renamed as this is probably a container restart and not first run."
+  fi
+fi
+
 # Credits https://github.com/kartoza/docker-geoserver/pull/371
 set_vars
 export  READONLY CLUSTER_DURABILITY BROKER_URL EMBEDDED_BROKER TOGGLE_MASTER TOGGLE_SLAVE BROKER_URL

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -33,10 +33,11 @@ source /scripts/env-data.sh
 # existing directory.
 if [ x"${GEOSERVER_CONTEXT_ROOT}" != xgeoserver ]; then
   echo "INFO: changing context-root to '${GEOSERVER_CONTEXT_ROOT}'."
-  if [ -e "${CATALINA_HOME}/webapps/geoserver" ]; then
-    mv "${CATALINA_HOME}/webapps/geoserver" "${CATALINA_HOME}/webapps/${GEOSERVER_CONTEXT_ROOT}"
+  GEOSERVER_INSTALL_DIR="$(detect_install_dir)"
+  if [ -e "${GEOSERVER_INSTALL_DIR}/webapps/geoserver" ]; then
+    mv "${GEOSERVER_INSTALL_DIR}/webapps/geoserver" "${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}"
   else
-    echo "WARN: '${CATALINA_HOME}/webapps/geoserver' not found, probably already renamed as this is probably a container restart and not first run."
+    echo "WARN: '${GEOSERVER_INSTALL_DIR}/webapps/geoserver' not found, probably already renamed as this is probably a container restart and not first run."
   fi
 fi
 

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -368,3 +368,7 @@ fi
 if [ -z "${USE_DEFAULT_CREDENTIALS}" ]; then
   USE_DEFAULT_CREDENTIALS=false
 fi
+
+if [ -z "${GEOSERVER_CONTEXT_ROOT}" ]; then
+  GEOSERVER_CONTEXT_ROOT=geoserver
+fi

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -370,5 +370,6 @@ if [ -z "${USE_DEFAULT_CREDENTIALS}" ]; then
 fi
 
 if [ -z "${GEOSERVER_CONTEXT_ROOT}" ]; then
+  # For runtime only, do not change at build-time.
   GEOSERVER_CONTEXT_ROOT=geoserver
 fi

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -129,6 +129,14 @@ function validate_geo_install() {
 
 }
 
+function detect_install_dir() {
+  if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
+    return "${GEOSERVER_HOME}"
+  else
+    return "${CATALINA_HOME}"
+  fi
+}
+
 function unzip_geoserver() {
   if [[ -f /tmp/geoserver/geoserver.war ]]; then
     unzip /tmp/geoserver/geoserver.war -d "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT} &&
@@ -246,11 +254,8 @@ function install_plugin() {
   if [[ -f "${DATA_PATH}"/"${EXT}".zip ]];then
      unzip "${DATA_PATH}"/"${EXT}".zip -d /tmp/gs_plugin
      echo -e "\e[32m Enabling ${EXT} for GeoServer \033[0m"
-     if [[ -f /geoserver/start.jar ]]; then
-       cp -r -u -p /tmp/gs_plugin/*.jar /geoserver/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/
-     else
-       cp -r -u -p /tmp/gs_plugin/*.jar "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/
-     fi
+     GEOSERVER_INSTALL_DIR="$(detect_install_dir)"
+     cp -r -u -p /tmp/gs_plugin/*.jar ${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/
      rm -rf /tmp/gs_plugin
   else
     echo -e "\e[32m ${EXT} extension will not be installed because it is not available \033[0m"

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -131,9 +131,9 @@ function validate_geo_install() {
 
 function detect_install_dir() {
   if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
-    return "${GEOSERVER_HOME}"
+    echo "${GEOSERVER_HOME}"
   else
-    return "${CATALINA_HOME}"
+    echo "${CATALINA_HOME}"
   fi
 }
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -131,12 +131,12 @@ function validate_geo_install() {
 
 function unzip_geoserver() {
   if [[ -f /tmp/geoserver/geoserver.war ]]; then
-    unzip /tmp/geoserver/geoserver.war -d "${CATALINA_HOME}"/webapps/geoserver &&
-    validate_geo_install "${CATALINA_HOME}"/webapps/geoserver && \
-    cp -r "${CATALINA_HOME}"/webapps/geoserver/data "${CATALINA_HOME}" &&
+    unzip /tmp/geoserver/geoserver.war -d "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT} &&
+    validate_geo_install "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT} && \
+    cp -r "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/data "${CATALINA_HOME}" &&
     mv "${CATALINA_HOME}"/data/security "${CATALINA_HOME}" &&
-    rm -rf "${CATALINA_HOME}"/webapps/geoserver/data &&
-    mv "${CATALINA_HOME}"/webapps/geoserver/WEB-INF/lib/postgresql-* "${CATALINA_HOME}"/postgres_config/ &&
+    rm -rf "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/data &&
+    mv "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/postgresql-* "${CATALINA_HOME}"/postgres_config/ &&
     rm -rf /tmp/geoserver
 else
     cp -r /tmp/geoserver/* "${GEOSERVER_HOME}"/ && \
@@ -247,9 +247,9 @@ function install_plugin() {
      unzip "${DATA_PATH}"/"${EXT}".zip -d /tmp/gs_plugin
      echo -e "\e[32m Enabling ${EXT} for GeoServer \033[0m"
      if [[ -f /geoserver/start.jar ]]; then
-       cp -r -u -p /tmp/gs_plugin/*.jar /geoserver/webapps/geoserver/WEB-INF/lib/
+       cp -r -u -p /tmp/gs_plugin/*.jar /geoserver/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/
      else
-       cp -r -u -p /tmp/gs_plugin/*.jar "${CATALINA_HOME}"/webapps/geoserver/WEB-INF/lib/
+       cp -r -u -p /tmp/gs_plugin/*.jar "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/
      fi
      rm -rf /tmp/gs_plugin
   else

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -105,7 +105,7 @@ fi
 if ls /tmp/resources/plugins/*.zip >/dev/null 2>&1; then
   for p in /tmp/resources/plugins/*.zip; do
     unzip "$p" -d /tmp/gs_plugin &&
-      mv /tmp/gs_plugin/*.jar "${GEOSERVER_INSTALL_DIR}"/webapps/geoserver/WEB-INF/lib/ &&
+      mv /tmp/gs_plugin/*.jar "${GEOSERVER_INSTALL_DIR}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/ &&
       rm -rf /tmp/gs_plugin
   done
 fi
@@ -115,39 +115,39 @@ fi
 #if [[ ${GDAL_VERSION:0:3} == 3.2 ]];then
 #  echo "gdal versions are the same"
 #else
-#  rm /usr/local/tomcat/webapps/geoserver/WEB-INF/lib/gdal-*
+#  rm /usr/local/tomcat/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/gdal-*
 #  validate_url https://repo1.maven.org/maven2/org/gdal/gdal/${GDAL_VERSION:0:3}.0/gdal-${GDAL_VERSION:0:3}.0.jar \
-#  '-O "${GEOSERVER_HOME}"/webapps/geoserver/WEB-INF/lib/gdal-${GDAL_VERSION:0:3}.0.jar'
+#  '-O "${GEOSERVER_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/gdal-${GDAL_VERSION:0:3}.0.jar'
 #fi
 
 
 # Install Marlin render https://www.geocat.net/docs/geoserver-enterprise/2020.5/install/production/marlin.html
 JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
 if [[ ${JAVA_VERSION} > 10 ]];then
-    if [[  -f $(find ${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib -regex ".*marlin-[0-9]\.[0-9]\.[0-9].*jar") ]]; then
-      mv ${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib/marlin-* ${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib/marlin-render.jar
+    if [[  -f $(find ${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib -regex ".*marlin-[0-9]\.[0-9]\.[0-9].*jar") ]]; then
+      mv ${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/marlin-* ${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/marlin-render.jar
     fi
 else
-    if [[ -f $(find ${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib -regex ".*marlin-[0-9]\.[0-9]\.[0-9].*jar") ]]; then
-      rm "${GEOSERVER_INSTALL_DIR}"/webapps/geoserver/WEB-INF/lib/marlin-* \
+    if [[ -f $(find ${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib -regex ".*marlin-[0-9]\.[0-9]\.[0-9].*jar") ]]; then
+      rm "${GEOSERVER_INSTALL_DIR}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/marlin-* \
       validate_url https://github.com/bourgesl/marlin-renderer/releases/download/v0_9_4_2_jdk9/marlin-0.9.4.2-Unsafe-OpenJDK9.jar && \
-      mv marlin-0.9.4.2-Unsafe-OpenJDK9.jar ${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib/marlin-render.jar
+      mv marlin-0.9.4.2-Unsafe-OpenJDK9.jar ${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/marlin-render.jar
     fi
 fi
 
 # Install jetty-servlets
 if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
-  if [[ ! -f ${GEOSERVER_HOME}/webapps/geoserver/WEB-INF/lib/jetty-servlets.jar ]]; then
+  if [[ ! -f ${GEOSERVER_HOME}/webapps/${GEOSERVER_CONTEXT_ROOT/WEB-INF/lib/jetty-servlets.jar ]]; then
     validate_url https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlets/11.0.9/jetty-servlets-11.0.9.jar \
-    '-O "${GEOSERVER_HOME}"/webapps/geoserver/WEB-INF/lib/jetty-servlets.jar'
+    '-O "${GEOSERVER_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/jetty-servlets.jar'
   fi
 fi
 
 # Install jetty-util
 if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
-  if [[ ! -f ${GEOSERVER_HOME}/webapps/geoserver/WEB-INF/lib/jetty-util.jar ]]; then
+  if [[ ! -f ${GEOSERVER_HOME}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/jetty-util.jar ]]; then
     validate_url https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/11.0.9/jetty-util-11.0.9.jar \
-      '-O "${GEOSERVER_HOME}"/webapps/geoserver/WEB-INF/lib/jetty-util.jar'
+      '-O "${GEOSERVER_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/jetty-util.jar'
   fi
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -95,11 +95,7 @@ dpkg -i ${resources_dir}/libjpeg-turbo-official_2.1.4_${system_architecture}.deb
 pushd "${CATALINA_HOME}" || exit
 
 # Install GeoServer plugins in correct install dir
-if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
-  GEOSERVER_INSTALL_DIR=${GEOSERVER_HOME}
-else
-  GEOSERVER_INSTALL_DIR=${CATALINA_HOME}
-fi
+GEOSERVER_INSTALL_DIR="$(detect_install_dir)"
 
 # Install any plugin zip files in resources/plugins
 if ls /tmp/resources/plugins/*.zip >/dev/null 2>&1; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -248,7 +248,7 @@ else
 
     if [[ "${ROOT_WEBAPP_REDIRECT}" =~ [Tt][Rr][Uu][Ee] ]]; then
         mkdir "${CATALINA_HOME}"/webapps/ROOT
-        cp /build_data/index.jsp "${CATALINA_HOME}"/webapps/ROOT/index.jsp
+        cat /build_data/index.jsp | sed "s@/geoserver/@/${GEOSERVER_CONTEXT_ROOT}/@g" > "${CATALINA_HOME}"/webapps/ROOT/index.jsp
     fi
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -200,9 +200,9 @@ if [[ ${POSTGRES_JNDI} =~ [Tt][Rr][Uu][Ee] ]];then
     POSTGRES_PORT=5432
     export POSTGRES_PORT="${POSTGRES_PORT}"
   fi
-  POSTGRES_JAR_COUNT=$(ls -1 ${CATALINA_HOME}/webapps/geoserver/WEB-INF/lib/postgresql-* 2>/dev/null | wc -l)
+  POSTGRES_JAR_COUNT=$(ls -1 ${CATALINA_HOME}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/postgresql-* 2>/dev/null | wc -l)
   if [ "$POSTGRES_JAR_COUNT" != 0 ]; then
-    rm "${CATALINA_HOME}"/webapps/geoserver/WEB-INF/lib/postgresql-*
+    rm "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/postgresql-*
   fi
   cp "${CATALINA_HOME}"/postgres_config/postgresql-* "${CATALINA_HOME}"/lib/
   if [[ -f ${EXTRA_CONFIG_DIR}/context.xml  ]]; then
@@ -213,7 +213,7 @@ if [[ ${POSTGRES_JNDI} =~ [Tt][Rr][Uu][Ee] ]];then
   fi
 
 else
-  cp "${CATALINA_HOME}"/postgres_config/postgresql-* "${CATALINA_HOME}"/webapps/geoserver/WEB-INF/lib/
+  cp "${CATALINA_HOME}"/postgres_config/postgresql-* "${CATALINA_HOME}"/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/
 fi
 
 

--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -48,7 +48,7 @@ if [[ "${USE_DEFAULT_CREDENTIALS}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
 
   USERS_XML=${USERS_XML:-${GEOSERVER_DATA_DIR}/security/usergroup/default/users.xml}
   ROLES_XML=${ROLES_XML:-${GEOSERVER_DATA_DIR}/security/role/default/roles.xml}
-  CLASSPATH=${CLASSPATH:-${GEOSERVER_INSTALL_DIR}/webapps/geoserver/WEB-INF/lib/}
+  CLASSPATH=${CLASSPATH:-${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}/WEB-INF/lib/}
 
   # users.xml setup
   cp $USERS_XML $USERS_XML.orig

--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -9,11 +9,7 @@ source /scripts/env-data.sh
 source /scripts/functions.sh
 
 # Setup install directory
-if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
-   GEOSERVER_INSTALL_DIR=${GEOSERVER_HOME}
-else
-  GEOSERVER_INSTALL_DIR=${CATALINA_HOME}
-fi
+GEOSERVER_INSTALL_DIR="$(detect_install_dir)"
 
 
 


### PR DESCRIPTION
Set env var `GEOSERVER_CONTEXT_ROOT=another-geoserver-context-root` and Geoserver will be accessible at https://hostname/another-geoserver-context-root/ instead of the default https://hostname/geoserver/.

I basically did a big find for `webapps/geoserver` and replace with `webapps/${GEOSERVER_CONTEXT_ROOT}` in all the scripts.

`GEOSERVER_CONTEXT_ROOT` default to `geoserver` if not set so this change is 100% backward compatible.

This is the fix to my problem described here https://stackoverflow.com/questions/75692310/is-it-possible-to-change-geoserver-context-root

I have a working docker image if you want to try this out: `pavics/geoserver:2.22.2-kartoza-build20230226-r4-allow-change-context-root`, built from this Dockerfile https://github.com/tlvu/docker-geoserver/blob/8023ada95a90e4c521c90025c6c134591acb5c59/Dockerfile.custom.  Docker image is used on our side in this PR https://github.com/bird-house/birdhouse-deploy-ouranos/pull/20

Without this fix, we see the following errors when the container starts:
```
cp: target '/usr/local/tomcat/webapps/ogc-geoserver/WEB-INF/lib/' is not a directory
Archive:  /community_plugins/colormap-plugin.zip
  inflating: /tmp/gs_plugin/gs-colormap-2.22-SNAPSHOT.jar
 Enabling colormap-plugin for GeoServer       
cp: cannot create regular file '/usr/local/tomcat/webapps/ogc-geoserver/WEB-INF/lib/': No such file or directory
cp: cannot create regular file '/usr/local/tomcat/webapps/ogc-geoserver/WEB-INF/lib/': No such file or directory
[Entrypoint] GENERATED tomcat  PASSWORD:  Oq2Ol5PYKKbIpr32tF 
 ----------------------------------------------------- 
  Run password encryption once for the first runtime 
find: ‘/usr/local/tomcat/webapps/ogc-geoserver/WEB-INF/lib/’: No such file or directory
Error: Could not find or load main class digest.sh
Caused by: java.lang.ClassNotFoundException: digest.sh
```