### PR TITLE
fixes #515

### DIFF
--- a/build_data/community_plugins.txt
+++ b/build_data/community_plugins.txt
@@ -3,7 +3,6 @@ backup-restore-plugin
 cog-plugin
 colormap-plugin
 cov-json-plugin
-csw-iso-plugin
 dds-plugin
 dyndimension-plugin
 elasticsearch-plugin
@@ -28,7 +27,6 @@ jms-cluster-plugin
 libdeflate-plugin
 mbtiles-plugin
 mbtiles-store-plugin
-metadata-plugin
 mongodb-schemaless-plugin
 ncwms-plugin
 netcdf-ghrsst-plugin

--- a/build_data/stable_plugins.txt
+++ b/build_data/stable_plugins.txt
@@ -3,6 +3,7 @@ authkey-plugin
 cas-plugin
 charts-plugin
 css-plugin
+csw-iso-plugin
 db2-plugin
 dxf-plugin
 excel-plugin
@@ -18,6 +19,7 @@ importer-plugin
 jp2k-plugin
 mapml-plugin
 mbstyle-plugin
+metadata-plugin
 mongodb-plugin
 mysql-plugin
 netcdf-out-plugin

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -82,10 +82,21 @@ export JAVA_OPTS="${JAVA_OPTS} ${GEOSERVER_OPTS}"
 
 
 # Chown again - seems to fix issue with resolving all created directories
-chown -R "${USER_NAME}":"${GEO_GROUP_NAME}" "${CATALINA_HOME}" "${FOOTPRINTS_DATA_DIR}" "${GEOSERVER_DATA_DIR}" \
-"${CERT_DIR}" "${FONTS_DIR}"  /home/"${USER_NAME}"/ "${COMMUNITY_PLUGINS_DIR}" "${STABLE_PLUGINS_DIR}" \
-"${GEOSERVER_HOME}" "${EXTRA_CONFIG_DIR}"  /usr/share/fonts/ /scripts /tomcat_apps.zip \
-/tmp/ "${GEOWEBCACHE_CACHE_DIR}";chmod o+rw "${CERT_DIR}";chmod 400 ${CATALINA_HOME}/conf/*
+CHOWN_LOCKFILE=/scripts/.permission_file.lock
+if [[ $(stat -c '%U' ${CATALINA_HOME}) != "${USER_NAME}" ]] && [[ $(stat -c '%G' ${CATALINA_HOME}) != "${GEO_GROUP_NAME}" ]];then
+  if [[ -f ${CHOWN_LOCKFILE} ]];then
+    rm ${CHOWN_LOCKFILE}
+  fi
+  if [[ ! -f ${CHOWN_LOCKFILE} ]];then
+    chown -R "${USER_NAME}":"${GEO_GROUP_NAME}" "${CATALINA_HOME}"   \
+    /home/"${USER_NAME}"/ "${COMMUNITY_PLUGINS_DIR}" "${STABLE_PLUGINS_DIR}" \
+    "${GEOSERVER_HOME}" /usr/share/fonts/ /scripts /tomcat_apps.zip /tmp/
+    touch ${CHOWN_LOCKFILE}
+  fi
+fi
+
+chown -R "${USER_NAME}":"${GEO_GROUP_NAME}"  "${FOOTPRINTS_DATA_DIR}" "${CERT_DIR}" "${FONTS_DIR}"  \
+   "${EXTRA_CONFIG_DIR}" ;chmod o+rw "${CERT_DIR}";gwc_file_perms ;chmod 400 ${CATALINA_HOME}/conf/*
 
 if [[ -f ${GEOSERVER_HOME}/start.jar ]]; then
   exec gosu ${USER_NAME} ${GEOSERVER_HOME}/bin/startup.sh

--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -365,3 +365,11 @@ fi
 if [ -z "${USE_DEFAULT_CREDENTIALS}" ]; then
   USE_DEFAULT_CREDENTIALS=false
 fi
+
+if [ -z "${CHOWN_DATA_DIR}" ]; then
+  CHOWN_DATA_DIR=true
+fi
+
+if [ -z "${CHOWN_GWC_DATA_DIR}" ]; then
+  CHOWN_GWC_DATA_DIR=true
+fi

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -429,3 +429,35 @@ function create_gwc_tile_tables(){
 
 }
 
+function gwc_file_perms() {
+  GEO_USER_PERM=$(stat -c '%U' ${GEOSERVER_DATA_DIR})
+  GEO_GRP_PERM=$(stat -c '%G' ${GEOSERVER_DATA_DIR})
+  GWC_USER_PERM=$(stat -c '%U' ${GEOWEBCACHE_CACHE_DIR})
+  GWC_GRP_PERM=$(stat -c '%G' ${GEOWEBCACHE_CACHE_DIR})
+  case "${GEOWEBCACHE_CACHE_DIR}" in ${GEOSERVER_DATA_DIR}/*)
+    echo "${GEOWEBCACHE_CACHE_DIR} is nested in ${GEOSERVER_DATA_DIR}"
+    if [[ ${CHOWN_DATA_DIR} =~ [Tt][Rr][Uu][Ee] ]];then
+      if [[ ${GEO_USER_PERM} != "${USER_NAME}" ]] &&  [[ ${GEO_GRP_PERM} != "${GEO_GROUP_NAME}"  ]];then
+        echo -e "[Entrypoint] Changing folder permission for: \e[1;31m ${GEOSERVER_DATA_DIR} \033[0m"
+        chown -R "${USER_NAME}":"${GEO_GROUP_NAME}" ${GEOSERVER_DATA_DIR}
+      fi
+    fi
+    ;;
+  *)
+    echo "${GEOWEBCACHE_CACHE_DIR} is not nested in ${GEOSERVER_DATA_DIR}"
+    if [[ ${CHOWN_DATA_DIR} =~ [Tt][Rr][Uu][Ee] ]];then
+      if [[ ${GEO_USER_PERM} != "${USER_NAME}" ]] &&  [[ ${GEO_GRP_PERM} != "${GEO_GROUP_NAME}"  ]];then
+        echo -e "[Entrypoint] Changing folder permission for: \e[1;31m ${GEOSERVER_DATA_DIR} \033[0m"
+        chown -R "${USER_NAME}":"${GEO_GROUP_NAME}" ${GEOSERVER_DATA_DIR}
+      fi
+    fi
+    if [[ ${CHOWN_GWC_DATA_DIR} =~ [Tt][Rr][Uu][Ee] ]];then
+      if [[ ${GWC_USER_PERM} != "${USER_NAME}" ]] &&  [[ ${GWC_GRP_PERM} != "${GEO_GROUP_NAME}"  ]];then
+        echo -e "[Entrypoint] Changing folder permission for: \e[1;31m ${GEOWEBCACHE_CACHE_DIR} \033[0m"
+        chown -R "${USER_NAME}":"${GEO_GROUP_NAME}" ${GEOWEBCACHE_CACHE_DIR}
+      fi
+    fi
+   ;;
+esac
+
+}


### PR DESCRIPTION
Added two env variables 
* CHOWN_DATA_DIR and CHOWN_GWC_DATA_DIR which default to true, this can be set to false to skip changing folder and file permission. The assumption is that a user should know the implications here as the startup will fail to create files in that directory without correct perms
* Added option to change perms only once for folders on startup unless the users change
* Added option to skip double chown of gwc and data dir is they are nested