### PR TITLE
fix web cors update

### DIFF
--- a/build_data/web.xml
+++ b/build_data/web.xml
@@ -603,6 +603,10 @@
             <param-value>*</param-value>
         </init-param>
         <init-param>
+            <param-name>cors.allowed.methods</param-name>
+            <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>
+        </init-param>
+        <init-param>
             <param-name>cors.allowed.headers</param-name>
             <param-value>Content-Type,X-Requested-With,accept,Access-Control-Request-Method,Access-Control-Request-Headers,If-Modified-Since,Range,Origin,Authorization</param-value>
         </init-param>
@@ -610,6 +614,18 @@
             <param-name>cors.exposed.headers</param-name>
             <param-value>Access-Control-Allow-Origin,Access-Control-Allow-Credentials</param-value>
         </init-param>
+        
+        <init-param>
+            <param-name>cors.support.credentials</param-name>
+            <param-value>false</param-value>
+        </init-param>
+
+
+        <init-param>
+            <param-name>cors.preflight.maxage</param-name>
+            <param-value>10</param-value>
+        </init-param>
+
     </filter>
 
     <filter-mapping>


### PR DESCRIPTION
* It seems setting `cors.support.credentials=true` breaks the image. These values are adapted from https://tomcat.apache.org/tomcat-9.0-doc/config/filter.html