### PR TITLE
Fixes #293 - although this is marked as resolved, the resolution isn't entirely correct

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -292,9 +292,6 @@ function activate_gwc_global_configs() {
       # default value
       envsubst < /build_data/gwc-gs.xml > "${GEOSERVER_DATA_DIR}"/gwc-gs.xml
     fi
-  else
-      # default value
-      envsubst < /build_data/gwc-gs.xml > "${GEOSERVER_DATA_DIR}"/gwc-gs.xml
   fi
 }
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -276,7 +276,7 @@ function jdbc_disk_quota_config() {
   if [[ ! -f "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml ]]; then
     # If it doesn't exists, copy from /settings directory if exists
     if [[ -f "${EXTRA_CONFIG_DIR}"/geowebcache-diskquota-jdbc.xml ]]; then
-      envsubst < "${EXTRA_CONFIG_DIR}"/geowebcache-diskquota-jdbc.xml < "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml
+      envsubst < "${EXTRA_CONFIG_DIR}"/geowebcache-diskquota-jdbc.xml > "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml
     else
       # default value
       envsubst < /build_data/geowebcache-diskquota-jdbc.xml > "${GEOWEBCACHE_CACHE_DIR}"/geowebcache-diskquota-jdbc.xml
@@ -287,7 +287,7 @@ function jdbc_disk_quota_config() {
 function activate_gwc_global_configs() {
   if [[ ! -f "${GEOSERVER_DATA_DIR}"/gwc-gs.xml ]]; then
     if [[ -f "${EXTRA_CONFIG_DIR}"/gwc-gs.xml ]]; then
-      envsubst < "${EXTRA_CONFIG_DIR}"/gwc-gs.xml < "${GEOSERVER_DATA_DIR}"/gwc-gs.xml
+      envsubst < "${EXTRA_CONFIG_DIR}"/gwc-gs.xml > "${GEOSERVER_DATA_DIR}"/gwc-gs.xml
     else
       # default value
       envsubst < /build_data/gwc-gs.xml > "${GEOSERVER_DATA_DIR}"/gwc-gs.xml

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -432,6 +432,10 @@ if [[ -f ${EXTRA_CONFIG_DIR}/server.xml ]]; then
 else
   # default value
   eval "$transform"
+  # Add x-forwarded headers
+  sed -r '/\<\Host\>/ i\ \t<Valve className="org.apache.catalina.valves.RemoteIpValve" remoteIpHeader="x-forwarded-for" remoteIpProxiesHeader="x-forwarded-by" protocolHeader="x-forwarded-proto" protocolHeaderHttpsValue="https"/>' ${CATALINA_HOME}/conf/server.xml > ${CATALINA_HOME}/conf/server.xml.tmp
+  cp ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/server.xml.orig
+  cp ${CATALINA_HOME}/conf/server.xml.tmp ${CATALINA_HOME}/conf/server.xml
 fi
 
 

--- a/sites-enabled/nginx.conf
+++ b/sites-enabled/nginx.conf
@@ -19,9 +19,11 @@ server {
 
     location / {
         proxy_pass http://geoserver/;
-        proxy_set_header    Host            $host;
-        proxy_set_header    X-Real-IP       $remote_addr;
-        proxy_set_header    X-Forwarded-for $remote_addr;
+        proxy_set_header    Host                $host;                      # the host requested by the client
+        proxy_set_header    X-Real-IP           $remote_addr;               # the real visitor IP
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for; # the client IP
+        proxy_set_header    X-Forwarded-Host    $host:$server_port;         # the host used for the request
+        proxy_set_header    X-Forwarded-Proto   $http_x_forwarded_proto;    # the scheme used for the request, http or https
         port_in_redirect off;
         proxy_connect_timeout 600;
     }


### PR DESCRIPTION
This can cause the local healthcheck to fail.
This fix is for hosting Geoserver behind an SSL layer e.g. AWS Load Balancer or Cloudfront. It will  allow it to be accessed via http OR https.
1. nginx.conf: the proxy headers are passed by the Nginx reverse proxy
2. server.xml: a fix for tomcat to accept the proxy scheme (e.g. https) using RemoteIpValve
*There may be a better way to write the xml insertion..