### PR TITLE
create intermedieate directories for GEOSERVER_CONTEXT_ROOT

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -35,6 +35,7 @@ if [ x"${GEOSERVER_CONTEXT_ROOT}" != xgeoserver ]; then
   echo "INFO: changing context-root to '${GEOSERVER_CONTEXT_ROOT}'."
   GEOSERVER_INSTALL_DIR="$(detect_install_dir)"
   if [ -e "${GEOSERVER_INSTALL_DIR}/webapps/geoserver" ]; then
+    mkdir -p "$(dirname -- "${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}")"
     mv "${GEOSERVER_INSTALL_DIR}/webapps/geoserver" "${GEOSERVER_INSTALL_DIR}/webapps/${GEOSERVER_CONTEXT_ROOT}"
   else
     echo "WARN: '${GEOSERVER_INSTALL_DIR}/webapps/geoserver' not found, probably already renamed as this is probably a container restart and not first run."


### PR DESCRIPTION
To support multipart CONTEXT_ROOT (for example `/prefix/geoserver`) the directory up to the last past needs to be created before moving the files.