### PR TITLE
fix overide custom crs and add option to overide default crs

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -58,15 +58,22 @@ function delete_folder() {
 # Function to add custom crs in geoserver data directory
 # https://docs.geoserver.org/latest/en/user/configuration/crshandling/customcrs.html
 function setup_custom_crs() {
-  if [[ ! -f ${GEOSERVER_DATA_DIR}/user_projections/epsg.properties ]]; then
-    # If it doesn't exists, copy from ${EXTRA_CONFIG_DIR} directory if exists
+    # If it exists, copy from ${EXTRA_CONFIG_DIR} directory if exists
     if [[ -f ${EXTRA_CONFIG_DIR}/epsg.properties ]]; then
-      cp -f "${EXTRA_CONFIG_DIR}"/epsg.properties "${GEOSERVER_DATA_DIR}"/user_projections/
+       cp -f "${EXTRA_CONFIG_DIR}"/epsg.properties "${GEOSERVER_DATA_DIR}"/user_projections/
     else
       # default values
-      cp -r "${CATALINA_HOME}"/data/user_projections/epsg.properties "${GEOSERVER_DATA_DIR}"/user_projections/epsg.properties
+      if [[ ! -f ${GEOSERVER_DATA_DIR}/user_projections/epsg.properties ]]; then
+        cp -r "${CATALINA_HOME}"/data/user_projections/epsg.properties "${GEOSERVER_DATA_DIR}"/user_projections/epsg.properties
+      fi
     fi
-  fi
+}
+
+function setup_custom_override_crs() {
+    # If it doesn't exists, copy from ${EXTRA_CONFIG_DIR} directory if exists
+    if [[ -f ${EXTRA_CONFIG_DIR}/epsg_overrides.properties ]]; then
+      cp -f "${EXTRA_CONFIG_DIR}"/epsg_overrides.properties"${GEOSERVER_DATA_DIR}"/user_projections/
+    fi
 }
 
 # Function to enable cors support thought tomcat

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -27,6 +27,7 @@ create_dir "${GEOSERVER_DATA_DIR}"/user_projections
 create_dir "${GEOWEBCACHE_CACHE_DIR}"
 
 setup_custom_crs
+setup_custom_override_crs
 
 create_dir "${GEOSERVER_DATA_DIR}"/logs
 export GEOSERVER_LOG_LEVEL
@@ -53,13 +54,16 @@ if [[  ${DB_BACKEND} =~ [Pp][Oo][Ss][Tt][Gg][Rr][Ee][Ss] ]]; then
   postgres_ssl_setup
   export DISK_QUOTA_BACKEND=JDBC
   export SSL_PARAMETERS=${PARAMS}
+  export POSTGRES_SCHEMA=${POSTGRES_SCHEMA}
   default_disk_quota_config
   jdbc_disk_quota_config
 
   echo -e "[Entrypoint] Checking PostgreSQL connection to see if diskquota tables are loaded: \033[0m"
-  export PGPASSWORD="${POSTGRES_PASS}"
-  postgres_ready_status ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB
-  create_gwc_tile_tables ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB $POSTGRES_SCHEMA
+  if [[  ${POSTGRES_SCHEMA} != 'public' ]]; then
+    export PGPASSWORD="${POSTGRES_PASS}"
+    postgres_ready_status ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB
+    create_gwc_tile_tables ${HOST} ${POSTGRES_PORT} ${POSTGRES_USER} $POSTGRES_DB $POSTGRES_SCHEMA
+  fi
 else
   export DISK_QUOTA_BACKEND=H2
   default_disk_quota_config


### PR DESCRIPTION
* Fix logic with mounted epsg file, always copy it on restart. This is useful if you keep on editing it outside the container and on restart new changes are red.
* Add option to add [epsg_overrides.properties](https://docs.geoserver.org/main/en/user/configuration/crshandling/customcrs.html#override-an-official-epsg-code)
* Fix logic with handling diskquota in DB, only create the tables manually if the schema is not `public`