### PR TITLE
Add ability to run as root

### DIFF
--- a/scripts/env-data.sh
+++ b/scripts/env-data.sh
@@ -387,3 +387,7 @@ if [ -z "${SHOW_PASSWORD}" ]; then
   # For runtime only, do not change at build-time.
   SHOW_PASSWORD=true
 fi
+
+if [ -z "${RUN_AS_ROOT}" ]; then
+  RUN_AS_ROOT=false
+fi


### PR DESCRIPTION
Keep the option to run as root, useful to use this in GeoNode where the container needs to run as root
Possibly fixes #528 