### PR TITLE
Add option to run additional script on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,14 @@ Example
 
 **Note:** The files `users.xml` and `roles.xml` should be mounted together to prevent errors
 during container start. Mounting these two files will overwrite `GEOSERVER_ADMIN_PASSWORD` and `GEOSERVER_ADMIN_USER`
+
+You can additionally run some bash script to correct some missing dependency i.e. in 
+community extension like [cluster issue](https://github.com/kartoza/docker-geoserver/issues/514)
+
+```bash
+-v ./run.sh:/docker-entrypoint-geoserver.d/run.sh
+```
+
 ### CORS Support
 
 The image ships with CORS support. If you however need to modify the web.xml you

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,7 +26,7 @@ source /scripts/env-data.sh
 
 # Create directories
 dir_creation=("${GEOSERVER_DATA_DIR}" "${CERT_DIR}" "${FOOTPRINTS_DATA_DIR}" "${FONTS_DIR}" "${GEOWEBCACHE_CACHE_DIR}"
-"${GEOSERVER_HOME}" "${EXTRA_CONFIG_DIR}")
+"${GEOSERVER_HOME}" "${EXTRA_CONFIG_DIR}" "/docker-entrypoint-geoserver.d")
 for directory in "${dir_creation[@]}"; do
   create_dir "${directory}"
 done
@@ -102,7 +102,7 @@ if [[ ${RUN_AS_ROOT} =~ [Ff][Aa][Ll][Ss][Ee] ]];then
   dir_ownership=("${CATALINA_HOME}" /home/"${USER_NAME}"/ "${COMMUNITY_PLUGINS_DIR}"
     "${STABLE_PLUGINS_DIR}" "${GEOSERVER_HOME}" /usr/share/fonts/ /tomcat_apps.zip
     /tmp/ "${FOOTPRINTS_DATA_DIR}" "${CERT_DIR}" "${FONTS_DIR}" /scripts/
-    "${EXTRA_CONFIG_DIR}")
+    "${EXTRA_CONFIG_DIR}" "/docker-entrypoint-geoserver.d")
   for directory in "${dir_ownership[@]}"; do
     if [[ $(stat -c '%U' "${directory}") != "${USER_NAME}" ]] && [[ $(stat -c '%G' "${directory}") != "${GEO_GROUP_NAME}" ]];then
       chown -R "${USER_NAME}":"${GEO_GROUP_NAME}" "${directory}"

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -523,3 +523,16 @@ function gwc_file_perms() {
 esac
 
 }
+
+function entry_point_script {
+
+  if find "/docker-entrypoint-geoserver.d" -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
+    for f in /docker-entrypoint-geoserver.d/*; do
+      case "$f" in
+            *.sh)     echo "$0: running $f"; . "$f" || true;;
+            *)        echo "$0: ignoring $f" ;;
+        esac
+        echo
+    done
+  fi
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -485,5 +485,8 @@ if [[ -z "${EXISTING_DATA_DIR}" ]]; then
   /scripts/update_passwords.sh
 fi
 
+# Run some extra bash script to fix issues i.e missing dependencies in lib caused by community extensions
+entry_point_script
+
 setup_logging
 


### PR DESCRIPTION
Fixes https://github.com/kartoza/docker-geoserver/issues/526 

* Add an option to run bash scripts during container startup. This could alleviate missing jars caused by tomcat version conflict or plugin missing jars, or allow a user to delete an existing jar