### PR TITLE
Update README and add test for nested context-root

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -47,6 +47,7 @@ jobs:
           - login
           - stores
           - context
+          - contexts
           - disk-quota
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -558,6 +558,14 @@ GEOSERVER_CONTEXT_ROOT=my-geoserver
 The example above will deploy Geoserver at https://host/my-geoserver instead of
 the default location at https://host/geoserver.
 
+It is also possible to do a nested context-root. [Apache Tomcat nested 
+context-roots are specified via #](https://octopus.com/blog/defining-tomcat-context-paths#conclusion).
+```
+GEOSERVER_CONTEXT_ROOT=foo#my-geoserver
+```
+The example above will deploy Geoserver at https://host/foo/my-geoserver 
+instead of the default location at https://host/geoserver.
+
 This variable is meant for runtime only.  At build-time, do not change this
 value so at runtime it can perform the proper context-root rename.
 

--- a/scenario_tests/contexts/docker-compose.yml
+++ b/scenario_tests/contexts/docker-compose.yml
@@ -1,0 +1,30 @@
+
+version: '2.1'
+
+volumes:
+  geoserver-data-dir:
+
+
+services:
+  geoserver:
+    image: 'kartoza/geoserver:${TAG:-manual-build}'
+    restart: 'always'
+    volumes:
+      - geoserver-data-dir:/opt/geoserver/data_dir
+      - ./tests:/tests
+    environment:
+      GEOSERVER_ADMIN_PASSWORD: myawesomegeoserver
+      GEOSERVER_ADMIN_USER: admin
+      INITIAL_MEMORY: 2G
+      MAXIMUM_MEMORY: 4G
+      GEOSERVER_CONTEXT_ROOT: foobar/geoserver
+      CONTAINER_NAME: geoserver
+      TEST_CLASS: test_login.TestGeoServerREST
+    healthcheck:
+      test: "curl --fail --silent --write-out 'HTTP CODE : %{http_code}\n' --output /dev/null -u admin:'myawesomegeoserver' http://localhost:8080/foobar/rest/about/version.xml"
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+
+
+

--- a/scenario_tests/contexts/docker-compose.yml
+++ b/scenario_tests/contexts/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       GEOSERVER_ADMIN_USER: admin
       INITIAL_MEMORY: 2G
       MAXIMUM_MEMORY: 4G
-      GEOSERVER_CONTEXT_ROOT: foobar/geoserver
+      GEOSERVER_CONTEXT_ROOT: foobar#geoserver
       CONTAINER_NAME: geoserver
       TEST_CLASS: test_login.TestGeoServerREST
     healthcheck:

--- a/scenario_tests/contexts/test.sh
+++ b/scenario_tests/contexts/test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# exit immediately if test fails
+set -e
+
+source ../test-env.sh
+
+# Run service
+if [[ $(dpkg -l | grep "docker-compose") > /dev/null ]];then
+    VERSION='docker-compose'
+  else
+    VERSION='docker compose'
+fi
+
+${VERSION} up -d
+
+if [[ -n "${PRINT_TEST_LOGS}" ]]; then
+  ${VERSION} logs -f &
+fi
+
+sleep 30
+
+
+services=("geoserver")
+
+for service in "${services[@]}"; do
+
+  # Execute tests
+  sleep 60
+  echo "Execute test for $service"
+  ${VERSION} exec -T $service /bin/bash /tests/test.sh
+
+done
+
+${VERSION} down -v

--- a/scenario_tests/contexts/tests/test.sh
+++ b/scenario_tests/contexts/tests/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+source /scripts/env-data.sh
+
+# execute tests
+pushd /tests
+
+cat << EOF
+Settings used:
+
+GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD}
+GEOSERVER_ADMIN_USER: ${GEOSERVER_ADMIN_USER}
+EOF
+
+python3 -m unittest -v ${TEST_CLASS}

--- a/scenario_tests/contexts/tests/test_login.py
+++ b/scenario_tests/contexts/tests/test_login.py
@@ -1,0 +1,41 @@
+import requests
+import unittest
+from os import environ
+
+
+class TestGeoServerREST(unittest.TestCase):
+
+    def setUp(self):
+        # Login to GeoServer and get the authentication cookies
+        self.base_url = 'http://localhost:8080/foobar/geoserver'
+        self.login_url = f'{self.base_url}/j_spring_security_check'
+        self.username = 'admin'
+        self.container_name = environ['CONTAINER_NAME']
+
+        if self.container_name == 'geoserver':
+            self.password = environ['GEOSERVER_ADMIN_PASSWORD']
+        else:
+            with open('/opt/geoserver/data_dir/security/pass.txt', 'r') as file:
+                file_pass = file.read()
+            self.password = file_pass.replace("\n", "")
+        self.session = requests.Session()
+        login_data = {
+            'username': self.username,
+            'password': self.password,
+            'submit': 'Login'
+        }
+        response = self.session.post(self.login_url, data=login_data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_rest_endpoints_accessible(self):
+        # Test if the REST endpoints are accessible as a logged user
+        url = f'{self.base_url}/rest/workspaces.json'
+        response = self.session.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json())
+
+    def tearDown(self):
+        # Logout from GeoServer
+        logout_url = f'{self.base_url}/j_spring_security_logout'
+        response = self.session.post(logout_url)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This PR addresses https://github.com/kartoza/docker-geoserver/issues/562.
Apache Tomcat is used to serve geoserver. 
Apache Tomcat uses # to denote a nested context root. See https://octopus.com/blog/defining-tomcat-context-paths#conclusion

Nested context root is still one folder in Tomcat which makes https://github.com/kartoza/docker-geoserver/pull/553 an unneeded change for a nested context root.