### PR TITLE
Use fonts-liberation, rather than side-loading mscorefonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN set -eux; \
     apt-get update; \
     apt-get -y --no-install-recommends install \
         locales gnupg2 wget ca-certificates rpl pwgen software-properties-common  iputils-ping \
-        apt-transport-https curl gettext fonts-cantarell lmodern ttf-aenigma \
-        ttf-bitstream-vera ttf-mscorefonts-installer ttf-sjfonts tv-fonts libapr1-dev libssl-dev git \
+        apt-transport-https curl gettext fonts-cantarell fonts-liberation lmodern ttf-aenigma \
+        ttf-bitstream-vera ttf-sjfonts tv-fonts libapr1-dev libssl-dev git \
         wget zip unzip curl xsltproc certbot  cabextract gettext postgresql-client figlet gosu gdal-bin libgdal-java; \
       dpkg-divert --local --rename --add /sbin/initctl \
       && (echo "Yes, do as I say!" | apt-get remove --force-yes login) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux; \
     apt-get -y --no-install-recommends install \
         locales gnupg2 wget ca-certificates rpl pwgen software-properties-common  iputils-ping \
         apt-transport-https curl gettext fonts-cantarell lmodern ttf-aenigma \
-        ttf-bitstream-vera ttf-sjfonts tv-fonts  libapr1-dev libssl-dev git \
+        ttf-bitstream-vera ttf-mscorefonts-installer ttf-sjfonts tv-fonts libapr1-dev libssl-dev git \
         wget zip unzip curl xsltproc certbot  cabextract gettext postgresql-client figlet gosu gdal-bin libgdal-java; \
       dpkg-divert --local --rename --add /sbin/initctl \
       && (echo "Yes, do as I say!" | apt-get remove --force-yes login) \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,13 +25,6 @@ package_geoserver
 cp /build_data/stable_plugins.txt /stable_plugins && cp /build_data/community_plugins.txt /community_plugins && \
 cp /build_data/letsencrypt-tomcat.xsl "${CATALINA_HOME}"/conf/ssl-tomcat.xsl
 
-# install microsoft fonts
-validate_url http://ftp.br.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.8.1_all.deb
-if [[ -f ttf-mscorefonts-installer_3.8.1_all.deb ]];then
- dpkg -i ttf-mscorefonts-installer_3.8.1_all.deb
- rm ttf-mscorefonts-installer_3.8.1_all.deb
-fi
-
 pushd "${STABLE_PLUGINS_DIR}" || exit
 
 # Check if we have pre downloaded plugin yet


### PR DESCRIPTION
The build scripts currently side-load `ttf-mscorefonts-installer` from an (official) Brazilian Debian mirror; which has problems:

* The Docker image appears to be based on Ubuntu Focal, and that package is for Debian.
* That mirror hostname is single-homed in Brazil, which isn't the fastest place to fetch stuff from out-of-continent – I get > 300 ms latency from Australia.
* Fetching and installing packages in this way is vulnerable to MITM attacks, as the package is fetched over HTTP and there are no signature checks (unlike using `apt`).
* There's no way for a user to accept or decline the EULA. [Ubuntu's version of the package gets explicit user consent](https://bugs.launchpad.net/ubuntu/+source/msttcorefonts/+bug/670629), but there's no way to provide this in a Docker context (either at build or run time).

To fix all of that, this replaces the fonts with less-encumbered equivalents in `fonts-liberation`. End-users can still sideload whatever fonts they like using the existing mechanisms (and that's OK).