### PR TITLE
Don't remove the login package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN set -eux; \
         ttf-bitstream-vera ttf-sjfonts tv-fonts  libapr1-dev libssl-dev git \
         wget zip unzip curl xsltproc certbot  cabextract gettext postgresql-client figlet gosu gdal-bin libgdal-java; \
       dpkg-divert --local --rename --add /sbin/initctl \
-      && (echo "Yes, do as I say!" | apt-get remove --force-yes login) \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*; \
       # verify that the binary works


### PR DESCRIPTION
It looks like the `login` package was marked for removal in https://github.com/kartoza/docker-geoserver/pull/45, in an attempt to reduce the final image size.

However, the `login` package is present in the `tomcat:9.0.85-jdk17-temurin-focal` base image:

```
$ docker run --rm -it tomcat:9.0.85-jdk17-temurin-focal dpkg -l login
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version                  Architecture Description
+++-==============-========================-============-=================================
ii  login          1:4.8.1-1ubuntu5.20.04.4 arm64        system login tools
```

While the running `geoserver` image will now report lower disk space usage, this doesn't actually have any effect on the image's true on-disk size – [it's still present in the base layers](https://docs.docker.com/storage/storagedriver/).

This PR just removes that command, because it has no effect.