### PR TITLE
Configure tomcat to log to stdout, instead of a file.

### DIFF
--- a/build_data/logging.properties
+++ b/build_data/logging.properties
@@ -1,0 +1,35 @@
+# Source: https://github.com/GoogleCloudPlatform/tomcat-runtime/pull/28/
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configure Tomcat to only log to stdout, rather than files. This ensures all
+# logs can be collected by the container runtime.
+
+handlers = java.util.logging.ConsoleHandler
+.handlers = java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.OneLineFormatter
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers =  java.util.logging.ConsoleHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = java.util.logging.ConsoleHandler

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,6 +24,7 @@ package_geoserver
 # Copy config files
 cp /build_data/stable_plugins.txt /stable_plugins && cp /build_data/community_plugins.txt /community_plugins && \
 cp /build_data/letsencrypt-tomcat.xsl "${CATALINA_HOME}"/conf/ssl-tomcat.xsl
+cp /build_data/logging.properties "${CATALINA_HOME}/conf/logging.properties"
 
 pushd "${STABLE_PLUGINS_DIR}" || exit
 


### PR DESCRIPTION
This PR makes Tomcat log everything to a `stdout`, instead of somewhere in `$CATALINA_HOME`.

Tomcat's servlet logs aren't available anywhere outside of the container, not even the GeoServer data directory. This makes it impossible to debug in many "serverless" cloud container runtimes, which delete a container instance's filesystem whenever the container terminates (even if it failed).

Most cloud providers recommend configuring containers to exclusively log to `stdout`, rather than files, so that they are collected in centralised systems as they are written.

Outside of cloud runtimes, one can use the `docker logs` command.

Ideally, everything else which currently logs to the `data` directory should be logged to `stdout` **only** as well. This has a few benefits:

* it doesn't fill up (limited) `tmpfs` space
* it doesn't duplicate logs which are already going to `stdout` or `stderr`
* it avoids locking issues with multiple instances of the GeoServer container attempting to write to the same file
* it moves the responsibility for rotating log files outside of the GeoServer application – so logging becomes append-only

However, I suspect that'll need GeoServer code changes, and that's a discussion to have later. 😄 

For now, this just moves Tomcat's logs, which are easy to do and not available elsewhere.

[This configuration file is from GCP's (now-deprecated) Tomcat runtime](https://github.com/GoogleCloudPlatform/tomcat-runtime/pull/28/), but still works well enough that I was able to debug an issue where GeoServer was crashing on start-up, but not logging anything useful to the data directory or `stdout`.

I've left Google's copyright and license notices in tact – I am not a Google employee.
