### PR TITLE
add note for forcing https on fargate

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ HTTP_PROXY_NAME=foo.org
 HTTP_SCHEME=https
 ```
 
+> Note: if you're running this on Fargate behind a load balancer that already terminates SSL, you only need `HTTP_SCHEME=https`.
+
 This will prevent the login form from sending insecure http post requests as experienced
 in [login issue](https://github.com/kartoza/docker-geoserver/issues/293)
 


### PR DESCRIPTION
I was puzzled for a bit about the relation between SSL on fargate vs nginx, but it all makes sense now, and I thought I would add this note for future travellers who also run into the same login issue, but are _not_ running behind nginx.