### PR TITLE
Fix db healthcheck with multiple db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         - FORCE_SSL=TRUE
       restart: on-failure
       healthcheck:
-        test: "PGPASSWORD=${POSTGRES_PASS} pg_isready -h 127.0.0.1 -U ${POSTGRES_USER} -d ${POSTGRES_DB}"
+        test: "pg_isready -h 127.0.0.1 -U ${POSTGRES_USER}"
         interval: 1m30s
         timeout: 10s
         retries: 3


### PR DESCRIPTION
Remove unnecessary (?) details on the `pg_isready` healthcheck call for the db.
See: <https://pgpedia.info/p/pg_isready.html> and #730