### PR TITLE
Add option to configure multiple users and roles

### DIFF
--- a/scenario_tests/login/docker-compose.yml
+++ b/scenario_tests/login/docker-compose.yml
@@ -62,3 +62,23 @@ services:
       timeout: 10s
       retries: 3
 
+  users:
+    image: 'kartoza/geoserver:${TAG:-manual-build}'
+    restart: 'always'
+    volumes:
+      - ./tests:/tests
+    environment:
+      GEOSERVER_ADMIN_PASSWORD: myawesomegeoserver,mygeoserver,mysample
+      GEOSERVER_ADMIN_USER: foo,myadmin,sample
+      INITIAL_MEMORY: 2G
+      MAXIMUM_MEMORY: 4G
+      CONTAINER_NAME: users
+      CONSOLE_HANDLER_LEVEL: WARNING
+      TEST_CLASS: test_login.TestGeoServerREST
+    ports:
+      - "8084:8080"
+    healthcheck:
+      test: [ "CMD-SHELL", "curl --fail --silent --write-out 'HTTP CODE : %{http_code}\n' --output /dev/null -u $${GEOSERVER_ADMIN_USER%%,*}:$${GEOSERVER_ADMIN_PASSWORD%%,*} http://localhost:8080/geoserver/rest/about/version.xml" ]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3

--- a/scenario_tests/login/test.sh
+++ b/scenario_tests/login/test.sh
@@ -14,7 +14,7 @@ if [[ -n "${PRINT_TEST_LOGS}" ]]; then
 fi
 
 
-services=("geoserver" "server" "credentials")
+services=("geoserver" "server" "credentials" "users")
 START_PORT=8081
 
 for i in "${!services[@]}"; do
@@ -32,14 +32,37 @@ for i in "${!services[@]}"; do
     USER="myadmin"
   fi
 
-  sleep 30
-  echo -e "[Unit Test] Test URL availability for: \e[1;31m $service \033[0m"
-  test_url_availability "http://localhost:$PORT/geoserver/rest/about/version.xml" "$PASS" "$USER"
 
-  echo -e "\e[32m ---------------------------------------- \033[0m"
-  echo -e "[Unit Test] Execute test for: \e[1;31m $service \033[0m"
-  ${VERSION} exec -T "$service" /bin/bash /tests/test.sh
+  if [[ "$service" != "users" ]];then
+    echo -e "[Unit Test] Test URL availability for: \e[1;31m $service \033[0m"
+    test_url_availability "http://localhost:$PORT/geoserver/rest/about/version.xml" "$PASS" "$USER"
+    echo -e "\e[32m ---------------------------------------- \033[0m"
+    echo -e "[Unit Test] Execute test for: \e[1;31m $service \033[0m"
+    ${VERSION} exec -T "$service" /bin/bash /tests/test.sh
+  else
+    # Execute tests
+    GEOSERVER_ADMIN_PASSWORD=myawesomegeoserver,mygeoserver,mysample
+    GEOSERVER_ADMIN_USER=foo,myadmin,sample
+    COUNT_GEOSERVER_ADMIN_PASSWORD=$(echo "$GEOSERVER_ADMIN_PASSWORD" | tr ',' '\n' | wc -l)
+    IFS=','
+    read -a geopass <<< "$GEOSERVER_ADMIN_PASSWORD"
+    read -a geouser <<< "$GEOSERVER_ADMIN_USER"
+    services=("users")
+    for i in "${!services[@]}"; do
+      service="${services[$i]}"
+      for ((i = 0; i < ${COUNT_GEOSERVER_ADMIN_PASSWORD}; i++)); do
+              USER="${geouser[$i]}"
+              PASS="${geopass[$i]}"
+              echo -e "[Unit Test] Test URL availability for: \e[1;31m $service with user $USER and pass $PASS \033[0m"
+              test_url_availability http://localhost:$PORT/geoserver/rest/about/version.xml ${PASS} ${USER}
+              echo "Execute test for $service"
+              docker compose exec -T "$service" /bin/bash /tests/test.sh
+      done
+    done
+
+  fi
+
 done
 
-${VERSION} down -v
 
+docker compose down -v

--- a/scenario_tests/login/tests/test_login.py
+++ b/scenario_tests/login/tests/test_login.py
@@ -11,25 +11,41 @@ class TestGeoServerREST(unittest.TestCase):
         self.login_url = f'{self.base_url}/j_spring_security_check'
         self.container_name = environ['CONTAINER_NAME']
 
-        if self.container_name == 'geoserver':
-            self.password = environ['GEOSERVER_ADMIN_PASSWORD']
-            self.username = 'admin'
-        elif self.container_name == 'credentials':
-            self.password = environ['GEOSERVER_ADMIN_PASSWORD']
-            self.username = 'myadmin'
-        elif self.container_name == 'server':
-            self.username = 'admin'
-            with open('/opt/geoserver/data_dir/security/pass.txt', 'r') as file:
-                file_pass = file.read()
-            self.password = file_pass.replace("\n", "")
-        self.session = requests.Session()
-        login_data = {
-            'username': self.username,
-            'password': self.password,
-            'submit': 'Login'
-        }
-        response = self.session.post(self.login_url, data=login_data)
-        self.assertEqual(response.status_code, 200)
+        if self.container_name =='users':
+
+            split_username = environ['GEOSERVER_ADMIN_USER'].split(',')
+            split_password = environ['GEOSERVER_ADMIN_PASSWORD'].split(',')
+            credentials = dict(zip(split_username, split_password))
+            for username, password in credentials.items():
+
+                self.session = requests.Session()
+                login_data = {
+                    'username': username,
+                    'password': password,
+                    'submit': 'Login'
+                }
+                response = self.session.post(self.login_url, data=login_data)
+                self.assertEqual(response.status_code, 200)
+        else:
+            if self.container_name == 'geoserver':
+                self.password = environ['GEOSERVER_ADMIN_PASSWORD']
+                self.username = 'admin'
+            elif self.container_name == 'credentials':
+                self.password = environ['GEOSERVER_ADMIN_PASSWORD']
+                self.username = 'myadmin'
+            elif self.container_name == 'server':
+                self.username = 'admin'
+                with open('/opt/geoserver/data_dir/security/pass.txt', 'r') as file:
+                    file_pass = file.read()
+                self.password = file_pass.replace("\n", "")
+            self.session = requests.Session()
+            login_data = {
+                'username': self.username,
+                'password': self.password,
+                'submit': 'Login'
+            }
+            response = self.session.post(self.login_url, data=login_data)
+            self.assertEqual(response.status_code, 200)
 
     def test_rest_endpoints_accessible(self):
         # Test if the REST endpoints are accessible as a logged user

--- a/scripts/update_passwords.sh
+++ b/scripts/update_passwords.sh
@@ -21,8 +21,7 @@ if [[ "${USE_DEFAULT_CREDENTIALS}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
   function password_reset() {
     cp -r ${CATALINA_HOME}/security ${GEOSERVER_DATA_DIR}
 
-      # Set random password if none provided
-      file_env 'GEOSERVER_ADMIN_PASSWORD'
+      # Create random password if none is provided
       if [[ -z ${GEOSERVER_ADMIN_PASSWORD} ]]; then
             generate_random_string 15
             GEOSERVER_ADMIN_PASSWORD=${RAND}
@@ -36,41 +35,55 @@ if [[ "${USE_DEFAULT_CREDENTIALS}" =~ [Ff][Aa][Ll][Ss][Ee] ]]; then
       fi
 
       # Get current GeoServer admin user
-      file_env GEOSERVER_ADMIN_USER
+      IFS=','
+      read -a geopass <<< "$GEOSERVER_ADMIN_PASSWORD"
+      file_env 'GEOSERVER_ADMIN_PASSWORD'
 
+      # Get current GeoServer admin user
+      IFS=','
+      read -a geouser <<< "$GEOSERVER_ADMIN_USER"
+      file_env GEOSERVER_ADMIN_USER
 
       export GEOSERVER_ADMIN_DEFAULT_USER='admin'
 
-
       # Get encrypted admin password
-      #export GEOSERVER_ADMIN_DEFAULT_ENCRYPTED_PASSWORD="$(sed -n 's/.*password="\([^"]*\)".*/\1/p' ${USERS_XML})"
 
-      export PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD $CLASSPATH $HASHING_ALGORITHM)
-      ESCAPED_GEOSERVER_ADMIN_USER=$(printf '%s\n' "$GEOSERVER_ADMIN_USER" | sed 's/[&/\]/\\&/g')
-      ESCAPED_PWD_HASH=$(printf '%s\n' "$PWD_HASH" | sed 's/[&/\]/\\&/g')
-      sed -i "s/name=\"[^\"]*\"/name=\"$ESCAPED_GEOSERVER_ADMIN_USER\"/; s/password=\"[^\"]*\"/password=\"$ESCAPED_PWD_HASH\"/" $USERS_XML
+      COUNT_GEOSERVER_ADMIN_USER=$(echo "$GEOSERVER_ADMIN_USER" | tr ',' '\n' | wc -l)
+      COUNT_GEOSERVER_ADMIN_PASSWORD=$(echo "$GEOSERVER_ADMIN_PASSWORD" | tr ',' '\n' | wc -l)
+      if [[ ${COUNT_GEOSERVER_ADMIN_USER} -eq ${COUNT_GEOSERVER_ADMIN_PASSWORD} ]]; then
 
-      # Set password encoding
-      sed -i 's/pbePasswordEncoder/strongPbePasswordEncoder/g' ${GEOSERVER_DATA_DIR}/security/config.xml
+        for ((i = 0; i < ${COUNT_GEOSERVER_ADMIN_PASSWORD}; i++)); do
+          user="${geouser[$i]}"
+          pass="${geopass[$i]}"
 
-      # roles.xml setup
-      cp $ROLES_XML $ROLES_XML.orig
-      # <userRoles username="admin">
-      cat $ROLES_XML.orig | sed -e "s/ username=\"${GEOSERVER_ADMIN_DEFAULT_USER}\"/ username=\"${GEOSERVER_ADMIN_USER}\"/" > $ROLES_XML
+          export PWD_HASH=$(make_hash "$pass" "$CLASSPATH" "$HASHING_ALGORITHM")
+          ESCAPED_GEOSERVER_ADMIN_USER=$(printf '%s\n' "$user" | sed 's/[&/\]/\\&/g')
+          ESCAPED_PWD_HASH=$(printf '%s\n' "$PWD_HASH" | sed 's/[&/\]/\\&/g')
+          if [[ $i -eq 0 ]]; then
+
+            sed -i "s/name=\"[^\"]*\"/name=\"$ESCAPED_GEOSERVER_ADMIN_USER\"/; s/password=\"[^\"]*\"/password=\"$ESCAPED_PWD_HASH\"/" "$USERS_XML"
+            cp "$ROLES_XML" "$ROLES_XML.orig"
+            sed -e "s/ username=\"${GEOSERVER_ADMIN_DEFAULT_USER}\"/ username=\"${user}\"/" "$ROLES_XML.orig" > "$ROLES_XML"
+          else
+            echo $ESCAPED_GEOSERVER_ADMIN_USER
+            sed -i "/<\/users>/i \    <user enabled=\"true\" name=\"$ESCAPED_GEOSERVER_ADMIN_USER\" password=\"$ESCAPED_PWD_HASH\"/>" "$USERS_XML"
+            sed -i "/<\/userList>/i \        <userRoles username=\"$ESCAPED_GEOSERVER_ADMIN_USER\">\n            <roleRef roleID=\"ADMIN\"/>\n        </userRoles>" "$ROLES_XML"
+          fi
+        done
+      else
+         echo -e "\e[32m -------------------------------------------------------------------------------- \033[0m"
+         echo -e "\e[32m [Entrypoint] Passwords and usernames have mismatch so we skip this and use:\033[0m \e[1;31m default credentials \033[0m"
+
+    fi
+    # Set password encoding
+    sed -i 's/pbePasswordEncoder/strongPbePasswordEncoder/g' ${GEOSERVER_DATA_DIR}/security/config.xml
 
 
   } # end password reset
 
-  if [[ -f ${USERS_XML} ]]; then
-    user_count=$(grep -o '<user ' ${USERS_XML} | wc -l)
-    if [[ "$user_count" -gt 1 ]]; then
-      echo -e "\e[32m [Entrypoint] More than one user exists :\033[0m \e[1;31m ${USERS_XML} \033[0m"
-    else
-      password_reset
-    fi
-  else
-    password_reset
-  fi
+
+  password_reset
+
 
 
 else


### PR DESCRIPTION

TODO
* update readme 


Add an option to pass, i.e
```
GEOSERVER_ADMIN_PASSWORD=myawesomegeoserver,mygeoserver,mysample
GEOSERVER_ADMIN_USER=foo,myadmin,sample
```
If there is a mismatch on number of users and password, the default creds are used to login
Currently there is no logic to parse passwords with comma separated i.e 
```
GEOSERVER_ADMIN_PASSWORD="'myawes,omegeoserver',mygeoserver,mysample"


